### PR TITLE
fix(consumer/koa): fix bug #22

### DIFF
--- a/lib/consumer/koa.js
+++ b/lib/consumer/koa.js
@@ -32,7 +32,13 @@ function Grant (_config) {
   }))
 
   app.use(route.get('/connect/:provider/:override?', function *(provider, override) {
-    if (override == 'callback') return yield callback
+    if (override == 'callback') {
+      if(this.session.grant) {
+        return yield callback
+      } else {
+        return this.response.redirect('/connect/' + provider)
+      }
+    }
 
     this.session.grant = {
       provider:provider,


### PR DESCRIPTION
FIxes #22 

With Koa
when access /connect/:provider/callback directory,  `this.session.grant` is undefined so throw error

```
TypeError: Cannot read property 'provider' of undefined
```