### PR TITLE
Switching Rdio to OAuth 2.0

### DIFF
--- a/config/oauth.json
+++ b/config/oauth.json
@@ -408,10 +408,9 @@
     "oauth": 2
   },
   "rdio": {
-    "request_url": "http://api.rdio.com/oauth/request_token",
-    "authorize_url": "https://www.rdio.com/oauth/authorize",
-    "access_url": "http://api.rdio.com/oauth/access_token",
-    "oauth": 1
+    "authorize_url": "https://www.rdio.com/oauth2/authorize",
+    "access_url": "https://services.rdio.com/oauth2/token",
+    "oauth": 2
   },
   "redbooth": {
     "authorize_url": "https://redbooth.com/oauth2/authorize",


### PR DESCRIPTION
On June 30th, 2015 Rdio officially disabled OAuth 1.0 service and switched completely over to OAuth 2.0.
http://blog.rdio.com/developers/2015/06/oauth-20-launch.html