### PR TITLE
add weibo provider

### DIFF
--- a/config/oauth.json
+++ b/config/oauth.json
@@ -619,6 +619,11 @@
     "access_url": "https://oauth.vk.com/access_token",
     "oauth": 2
   },
+  "weibo": {
+    "authorize_url": "https://api.weibo.com/oauth2/authorize",
+    "access_url": "https://api.weibo.com/oauth2/access_token",
+    "oauth": 2
+  },
   "withings": {
     "request_url": "https://oauth.withings.com/account/request_token",
     "authorize_url": "https://oauth.withings.com/account/authorize",


### PR DESCRIPTION
Sina Weibo, domain: [weibo.com](http://weibo.com/), is chinese twitter equivalent, [currently has around 500 million users](https://en.wikipedia.org/wiki/List_of_virtual_communities_with_more_than_100_million_active_users).

But my PR is necessary also because `grant-koa` doesn't appear to mount our custom provider properly, I got 404 on `/connect/weibo` even though my config contains this:

```
		weibo: {
			key: '...'
			, secret: '...'
			, callback: '/login/weibo'
			, type: 2
			, authorize_url: 'https://api.weibo.com/oauth2/authorize'
			, access_url: 'https://api.weibo.com/oauth2/access_token'
		}
```

My twitter and github config are working fine in the meanwhile.
