### PR TITLE
allow custom_parameters as an object

### DIFF
--- a/lib/flow/oauth1.js
+++ b/lib/flow/oauth1.js
@@ -41,11 +41,17 @@ exports.step2 = function (provider, step1) {
     oauth_token:step1.oauth_token
   }
   if (provider.custom_parameters) {
-    provider.custom_parameters.forEach(function (key) {
-      params[key] = (provider.flickr && key == 'perms')
-        ? provider.scope
-        : provider[key]
-    })
+    if (Array.isArray(provider.custom_parameters)) {
+      provider.custom_parameters.forEach(function (key) {
+        params[key] = (provider.flickr && key == 'perms')
+          ? provider.scope
+          : provider[key]
+      })
+    } else if (typeof provider.custom_parameters === 'object') {
+      for (var key in provider.custom_parameters) {
+        params[key] = provider.custom_parameters[key]
+      }
+    }
   }
   if (provider.tripit) {
     params.oauth_callback = utils.redirect_uri(provider)

--- a/lib/flow/oauth2.js
+++ b/lib/flow/oauth2.js
@@ -21,9 +21,15 @@ exports.step1 = function (provider) {
     params.api_key = provider.api_key
   }
   if (provider.custom_parameters) {
-    provider.custom_parameters.forEach(function (key) {
-      params[key] = provider[key]
-    })
+    if (Array.isArray(provider.custom_parameters)) {
+      provider.custom_parameters.forEach(function (key) {
+        params[key] = provider[key]
+      })
+    } else if (typeof provider.custom_parameters === 'object') {
+      for (var key in provider.custom_parameters) {
+        params[key] = provider.custom_parameters[key]
+      }
+    }
   }
   if (provider.subdomain) {
     url = url.replace('[subdomain]',provider.subdomain)

--- a/test/flow/oauth1.js
+++ b/test/flow/oauth1.js
@@ -198,21 +198,45 @@ describe('oauth1', function () {
       })
 
       describe('custom_parameters', function () {
-        it('flickr', function () {
-          grant.config.flickr.scope = ['read','write']
-          var url = oauth1.step2(grant.config.flickr, {oauth_token:'token'})
-          var query = qs.parse(url.split('?')[1])
-          should.deepEqual(query,
-            {oauth_token:'token', perms:['read','write']})
+        describe('as array',function () {
+          it('flickr', function () {
+            grant.config.flickr.scope = ['read','write']
+            var url = oauth1.step2(grant.config.flickr, {oauth_token:'token'})
+            var query = qs.parse(url.split('?')[1])
+            should.deepEqual(query,
+              {oauth_token:'token', perms:['read','write']})
+          })
+
+          it('trello', function () {
+            grant.config.trello.scope = ['read','write']
+            grant.config.trello.expiration = 'never'
+            var url = oauth1.step2(grant.config.trello, {oauth_token:'token'})
+            var query = qs.parse(url.split('?')[1])
+            should.deepEqual(query,
+              {oauth_token:'token', scope:['read','write'], expiration:'never'})
+          })
         })
 
-        it('trello', function () {
-          grant.config.trello.scope = ['read','write']
-          grant.config.trello.expiration = 'never'
-          var url = oauth1.step2(grant.config.trello, {oauth_token:'token'})
-          var query = qs.parse(url.split('?')[1])
-          should.deepEqual(query,
-            {oauth_token:'token', scope:['read','write'], expiration:'never'})
+        describe('as object', function () {
+          it('flickr', function () {
+            grant.config.flickr.custom_parameters = {perms: ['read','write']}
+            var url = oauth1.step2(grant.config.flickr, {oauth_token:'token'})
+            var query = qs.parse(url.split('?')[1])
+            should.deepEqual(query,
+              {oauth_token:'token', perms:['read','write']})
+          })
+
+          it('trello', function () {
+            grant.config.trello.custom_parameters = {
+              scope:['read','write'],
+              expiration:'never',
+              name: 'random'
+            }
+            var url = oauth1.step2(grant.config.trello, {oauth_token:'token'})
+            var query = qs.parse(url.split('?')[1])
+            should.deepEqual(query,
+              {oauth_token:'token', scope:['read','write'], expiration:'never', name:'random'})
+          })
         })
       })
 

--- a/test/flow/oauth2.js
+++ b/test/flow/oauth2.js
@@ -136,50 +136,100 @@ describe('oauth2', function () {
       })
 
       describe('custom_parameters', function () {
-        it('coinbase', function () {
-          grant.config.coinbase.meta = {
-            send_limit_amount:'5', send_limit_currency:'USD', send_limit_period:'day'
-          }
-          var url = oauth2.step1(grant.config.coinbase)
-          var query = qs.parse(url.split('?')[1])
-          should.deepEqual(query.meta, {
-            send_limit_amount:'5', send_limit_currency:'USD', send_limit_period:'day'
+        describe('as array', function () {
+          it('coinbase', function () {
+            grant.config.coinbase.meta = {
+              send_limit_amount:'5', send_limit_currency:'USD', send_limit_period:'day'
+            }
+            var url = oauth2.step1(grant.config.coinbase)
+            var query = qs.parse(url.split('?')[1])
+            should.deepEqual(query.meta, {
+              send_limit_amount:'5', send_limit_currency:'USD', send_limit_period:'day'
+            })
+          })
+
+          it('google', function () {
+            grant.config.google.access_type = 'offline'
+            var url = oauth2.step1(grant.config.google)
+            var query = qs.parse(url.split('?')[1])
+            query.access_type.should.equal('offline')
+          })
+
+          it('reddit', function () {
+            grant.config.reddit.duration = 'permanent'
+            var url = oauth2.step1(grant.config.reddit)
+            var query = qs.parse(url.split('?')[1])
+            query.duration.should.equal('permanent')
+          })
+
+          it('spotify', function () {
+            grant.config.spotify.show_dialog = 'true'
+            var url = oauth2.step1(grant.config.spotify)
+            var query = qs.parse(url.split('?')[1])
+            query.show_dialog.should.equal('true')
+          })
+
+          it('surveymonkey', function () {
+            grant.config.surveymonkey.api_key = 'api_key'
+            var url = oauth2.step1(grant.config.surveymonkey)
+            var query = qs.parse(url.split('?')[1])
+            query.api_key.should.equal('api_key')
+          })
+
+          it('wordpress', function () {
+            grant.config.wordpress.blog = 'Grant'
+            var url = oauth2.step1(grant.config.wordpress)
+            var query = qs.parse(url.split('?')[1])
+            query.blog.should.equal('Grant')
           })
         })
 
-        it('google', function () {
-          grant.config.google.access_type = 'offline'
-          var url = oauth2.step1(grant.config.google)
-          var query = qs.parse(url.split('?')[1])
-          query.access_type.should.equal('offline')
-        })
+        describe('as object', function () {
+          it('coinbase', function () {
+            grant.config.coinbase.custom_parameters = {meta:{
+              send_limit_amount:'5', send_limit_currency:'USD', send_limit_period:'day'
+            }}
+            var url = oauth2.step1(grant.config.coinbase)
+            var query = qs.parse(url.split('?')[1])
+            should.deepEqual(query.meta, {
+              send_limit_amount:'5', send_limit_currency:'USD', send_limit_period:'day'
+            })
+          })
 
-        it('reddit', function () {
-          grant.config.reddit.duration = 'permanent'
-          var url = oauth2.step1(grant.config.reddit)
-          var query = qs.parse(url.split('?')[1])
-          query.duration.should.equal('permanent')
-        })
+          it('google', function () {
+            grant.config.google.custom_parameters = {access_type:'offline'}
+            var url = oauth2.step1(grant.config.google)
+            var query = qs.parse(url.split('?')[1])
+            query.access_type.should.equal('offline')
+          })
 
-        it('spotify', function () {
-          grant.config.spotify.show_dialog = 'true'
-          var url = oauth2.step1(grant.config.spotify)
-          var query = qs.parse(url.split('?')[1])
-          query.show_dialog.should.equal('true')
-        })
+          it('reddit', function () {
+            grant.config.reddit.custom_parameters = {duration:'permanent'}
+            var url = oauth2.step1(grant.config.reddit)
+            var query = qs.parse(url.split('?')[1])
+            query.duration.should.equal('permanent')
+          })
 
-        it('surveymonkey', function () {
-          grant.config.surveymonkey.api_key = 'api_key'
-          var url = oauth2.step1(grant.config.surveymonkey)
-          var query = qs.parse(url.split('?')[1])
-          query.api_key.should.equal('api_key')
-        })
+          it('spotify', function () {
+            grant.config.spotify.custom_parameters = {show_dialog:'true'}
+            var url = oauth2.step1(grant.config.spotify)
+            var query = qs.parse(url.split('?')[1])
+            query.show_dialog.should.equal('true')
+          })
 
-        it('wordpress', function () {
-          grant.config.wordpress.blog = 'Grant'
-          var url = oauth2.step1(grant.config.wordpress)
-          var query = qs.parse(url.split('?')[1])
-          query.blog.should.equal('Grant')
+          it('surveymonkey', function () {
+            grant.config.surveymonkey.custom_parameters = {api_key:'api_key'}
+            var url = oauth2.step1(grant.config.surveymonkey)
+            var query = qs.parse(url.split('?')[1])
+            query.api_key.should.equal('api_key')
+          })
+
+          it('wordpress', function () {
+            grant.config.wordpress.custom_parameters = {blog:'Grant'}
+            var url = oauth2.step1(grant.config.wordpress)
+            var query = qs.parse(url.split('?')[1])
+            query.blog.should.equal('Grant')
+          })
         })
       })
 


### PR DESCRIPTION
Fixes #29

This is a small change that allow using an object instead of an array as custom parameters, making reserved words (typically `name`) usable in parameters.