### PR TITLE
add uber-china authorization

### DIFF
--- a/config/oauth.json
+++ b/config/oauth.json
@@ -804,6 +804,11 @@
     "access_url": "https://login.uber.com/oauth/token",
     "oauth": 2
   },
+  "uber-china": {
+    "authorize_url": "https://login.uber.com.cn/oauth/authorize",
+    "access_url": "https://login.uber.com.cn/oauth/token",
+    "oauth": 2
+  },
   "underarmour": {
     "authorize_url": "https://www.mapmyfitness.com/v7.1/oauth2/uacf/authorize",
     "access_url": "https://api.mapmyfitness.com/v7.1/oauth2/access_token",


### PR DESCRIPTION
Find out Uber China has different authorization link with Uber global:
https://developer.uber.com.cn/docs/authentication   

```js
"uber-china": {
    "authorize_url": "https://login.uber.com.cn/oauth/authorize",
    "access_url": "https://login.uber.com.cn/oauth/token",
    "oauth": 2
  },
```