### PR TITLE
Added scope_data custom param to Amazon

### DIFF
--- a/config/oauth.json
+++ b/config/oauth.json
@@ -31,7 +31,8 @@
     "authorize_url": "https://www.amazon.com/ap/oa",
     "access_url": "https://api.amazon.com/auth/o2/token",
     "oauth": 2,
-    "scope_delimiter": " "
+    "scope_delimiter": " ",
+    "custom_parameters" : ["scope_data"]
   },
   "angellist": {
     "authorize_url": "https://angel.co/api/oauth/authorize",


### PR DESCRIPTION
scope_data is required for Alexa Voice Service
(https://developer.amazon.com/public/solutions/alexa/alexa-voice-service/docs/authorizing-your-alexa-enabled-product-from-a-website)