### PR TITLE
Fix typo in hosts file example.

### DIFF
--- a/examples/koa/README.md
+++ b/examples/koa/README.md
@@ -13,7 +13,7 @@ $ npm install
 
 Create OAuth application for Facebook and Twitter. For Twitter set the callback url to be `http://dummy.com:3000/connect/twitter/callback`, for Facebook set the application domain to be `dummy.com`
 
-In your `hosts` file add this line `dummy.com 127.0.0.1`
+In your `hosts` file add this line `127.0.0.1 dummy.com`
 
 
 ## Configure


### PR DESCRIPTION
Hi.  I haven't worked with the hosts file before, so maybe I'm just not understanding something -- but the redirect didn't work for me until I tried switching the parameters like this.  It confused me for a while.  This is on OS X 10.11.2.