### PR TITLE
Added rule to ignore grant routes on lout documentation

### DIFF
--- a/lib/consumer/hapi.js
+++ b/lib/consumer/hapi.js
@@ -47,6 +47,11 @@ Grant.prototype.register = function (server, options, next) {
       ;(req.session || req.yar).set('grant', session)
 
       connect(req, res)
+    },
+    config: {
+      plugins: {
+        lout: false
+      }
     }
   })
 
@@ -150,6 +155,11 @@ Grant.prototype.register = function (server, options, next) {
       else {
         var err = {error: 'Grant: missing session or misconfigured provider'}
         callback(qs.stringify(err))
+      }
+    },
+    config: {
+      plugins: {
+        lout: false
       }
     }
   })


### PR DESCRIPTION
When using the plugin `lout` with `hapi`, the routes generated with
`grant` appear in the documentation generated. As these are private
routes, I don’t believe they should be shown.

This fix adds the ignore rules as specified in the `lout` documentation:
https://github.com/hapijs/lout#ignoring-a-route-in-documentation

Without the plugin installed the configuration is ignored.