### PR TITLE
use https for tumblr endpoints

### DIFF
--- a/config/oauth.json
+++ b/config/oauth.json
@@ -857,9 +857,9 @@
     "oauth": 1
   },
   "tumblr": {
-    "request_url": "http://www.tumblr.com/oauth/request_token",
-    "authorize_url": "http://www.tumblr.com/oauth/authorize",
-    "access_url": "http://www.tumblr.com/oauth/access_token",
+    "request_url": "https://www.tumblr.com/oauth/request_token",
+    "authorize_url": "https://www.tumblr.com/oauth/authorize",
+    "access_url": "https://www.tumblr.com/oauth/access_token",
     "oauth": 1
   },
   "twitch": {


### PR DESCRIPTION
up until a couple days ago tumblr appeared to support either `http` or `https` for their OAuth endpoints, but now it's strictly `https`-only