### PR TITLE
id_token audience claim can be an array

### DIFF
--- a/lib/id_token.js
+++ b/lib/id_token.js
@@ -1,3 +1,4 @@
+const isAudienceValid = (aud, key) => (Array.isArray(aud) && aud.indexOf(key) !== -1) || aud === key;
 
 module.exports = (provider, body, session) => {
 
@@ -14,7 +15,7 @@ module.exports = (provider, body, session) => {
     return {error: 'Grant: OpenID Connect error decoding id_token'}
   }
 
-  if (payload.aud !== provider.key) {
+  if (!isAudienceValid(payload.aud, provider.key)) {
     return {error: 'Grant: OpenID Connect invalid id_token audience'}
   }
   else if ((payload.nonce && session.nonce) && (payload.nonce !== session.nonce)) {

--- a/test/id_token.js
+++ b/test/id_token.js
@@ -29,7 +29,7 @@ describe('id_token', () => {
     )
   })
 
-  it('invalid audience', () => {
+  it('invalid audience (string)', () => {
     var id_token = sign({}, {aud: 'grant'}, 'c')
     var {error} = verify({key: 'simov'}, {id_token})
     t.equal(
@@ -37,6 +37,22 @@ describe('id_token', () => {
       'Grant: OpenID Connect invalid id_token audience'
     )
   })
+
+  it('valid audience (array)', () => {
+    var id_token = sign({}, {aud: ['grant']}, 'c')
+    var {error} = verify({key: 'grant'}, {id_token})
+    t.equal(error, undefined);
+  })
+
+  it('invalid audience (array)', () => {
+    var id_token = sign({}, {aud: ['grant']}, 'c')
+    var {error} = verify({key: 'simov'}, {id_token})
+    t.equal(
+      error,
+      'Grant: OpenID Connect invalid id_token audience'
+    )
+  });
+
 
   it('nonce mismatch', () => {
     var id_token = sign({}, {aud: 'grant', nonce: 'foo'}, 'c')


### PR DESCRIPTION
According to the RFC 7519, the audience claim in id_token is an array of case sensitive strings; only in case the jwt has one audience, this may be a string.

https://tools.ietf.org/html/rfc7519#page-9

Side note: according to the RFC, "The interpretation of audience values is generally application specific". I'm not sure how much of a coincidence it is that most of the implementations checks for the client ID. Could it be a possibility to have the claim check function as an optional parameter to be passed to grant?