### PR TITLE
Use URL constructor in the koa2 redirect callback

### DIFF
--- a/lib/consumer/koa2.js
+++ b/lib/consumer/koa2.js
@@ -68,7 +68,9 @@ module.exports = function (_config) {
       ctx.body = qs.stringify(data)
     }
     else if (!provider.transport || provider.transport === 'querystring') {
-      ctx.response.redirect(`${provider.callback}?${qs.stringify(data)}`)
+      var callbackUrl = new URL(provider.callback)
+      callbackUrl.search = new URLSearchParams(data)
+      ctx.response.redirect(callbackUrl.href)
     }
     else if (provider.transport === 'session') {
       session.response = data


### PR DESCRIPTION
Build the URL using the native `URL` & `URLSearchParams` JavaScript constructors instead of a library to parse the params and a manual string concatenation.