### PR TITLE
Add authentication method for the token endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,7 @@ callback | `[provider]` | final callback route on your server to receive the [re
 dynamic | `[provider]` | allow [dynamic override](#dynamic-override) of configuration
 overrides | `[provider]` | [static overrides](#static-overrides) for a provider
 response | `[provider]` | [limit](#limit-response-data) the response data
+token_endpoint_auth_method | `[provider]` | Authentication method for the token endpoint from [RFC 7591](https://tools.ietf.org/html/rfc7591#section-2)
 name | generated | provider's [name](#grant), used to generate `redirect_uri`
 [provider] | generated | provider's [name](#grant) as key
 redirect_uri | generated | OAuth app [redirect URI](#redirect-uri), generated using `protocol`, `host`, `path` and `name`

--- a/config/reserved.json
+++ b/config/reserved.json
@@ -5,6 +5,7 @@
   "oauth",
   "scope_delimiter",
   "custom_parameters",
+  "token_endpoint_auth_method",
 
   "protocol",
   "host",

--- a/lib/config.js
+++ b/lib/config.js
@@ -137,6 +137,15 @@ var format = {
     return Object.keys(overrides).length ? overrides : undefined
   },
 
+  // https://tools.ietf.org/html/rfc7591#section-2
+  token_endpoint_auth_method: ({oauth, token_endpoint_auth_method}) => {
+    // There is no `none` method since it's used only with public clients
+    var defaults = ['client_secret_post', 'client_secret_basic']
+
+    return oauth === 2
+    ? defaults.includes(token_endpoint_auth_method) ? token_endpoint_auth_method : defaults[0]
+    : undefined
+  }
 }
 
 var state = (provider, key = 'state', value = provider[key]) =>

--- a/lib/flow/oauth2.js
+++ b/lib/flow/oauth2.js
@@ -78,7 +78,9 @@ exports.access = (provider, authorize, session) => new Promise((resolve, reject)
       client_secret: provider.secret
     }
   }
-  if (/ebay|fitbit2|homeaway|hootsuite|reddit/.test(provider.name)) {
+  if (/ebay|fitbit2|homeaway|hootsuite|reddit/.test(provider.name)
+    || provider.token_endpoint_auth_method === 'client_secret_basic'
+  ) {
     delete options.form.client_id
     delete options.form.client_secret
     options.auth = {user: provider.key, pass: provider.secret}

--- a/test/config.js
+++ b/test/config.js
@@ -82,6 +82,15 @@ describe('config', () => {
       t.equal(config.format.secret({oauth: 3, secret: 'secret'}), undefined)
       t.equal(config.format.secret({}), undefined)
     })
+    it('token_endpoint_auth_method', () => {
+      t.equal(config.format.token_endpoint_auth_method({}), undefined)
+      t.equal(config.format.token_endpoint_auth_method({oauth: undefined}), undefined)
+      t.equal(config.format.token_endpoint_auth_method({oauth: 1}), undefined)
+      t.equal(config.format.token_endpoint_auth_method({oauth: 2}), 'client_secret_post')
+      t.equal(config.format.token_endpoint_auth_method({oauth: 2, token_endpoint_auth_method: 'foo'}), 'client_secret_post')
+      t.equal(config.format.token_endpoint_auth_method({oauth: 2, token_endpoint_auth_method: 'client_secret_basic'}), 'client_secret_basic')
+      t.equal(config.format.token_endpoint_auth_method({oauth: 2, token_endpoint_auth_method: 'client_secret_post'}), 'client_secret_post')
+    })
     it('scope', () => {
       t.equal(config.format.scope({scope: []}), undefined)
       t.equal(config.format.scope({scope: ['']}), undefined)
@@ -243,6 +252,7 @@ describe('config', () => {
         {
           protocol: 'http',
           host: 'localhost:3000',
+          token_endpoint_auth_method: 'client_secret_post',
           oauth: 2,
           client_id: 'key',
           client_secret: 'secret',
@@ -255,6 +265,7 @@ describe('config', () => {
             sub: {
               protocol: 'http',
               host: 'localhost:3000',
+              token_endpoint_auth_method: 'client_secret_post',
               oauth: 2,
               client_id: 'key',
               client_secret: 'secret',
@@ -285,6 +296,7 @@ describe('config', () => {
         facebook: {
           authorize_url: 'https://www.facebook.com/dialog/oauth',
           access_url: 'https://graph.facebook.com/oauth/access_token',
+          token_endpoint_auth_method: 'client_secret_post',
           oauth: 2,
           protocol: 'http',
           host: 'localhost:3000',
@@ -307,6 +319,7 @@ describe('config', () => {
         facebook: {
           authorize_url: 'https://www.facebook.com/dialog/oauth',
           access_url: 'https://graph.facebook.com/oauth/access_token',
+          token_endpoint_auth_method: 'client_secret_post',
           oauth: 2,
           protocol: 'http',
           host: 'localhost:3000',
@@ -344,6 +357,7 @@ describe('config', () => {
         config.provider(options, session), {
           authorize_url: 'https://www.facebook.com/dialog/oauth',
           access_url: 'https://graph.facebook.com/oauth/access_token',
+          token_endpoint_auth_method: 'client_secret_post',
           oauth: 2,
           dynamic: true,
           name: 'facebook',


### PR DESCRIPTION
Hi there,

This PR adds ability to set authentication method for the token endpoint for OAuth 2.0.

**Reason**
There is no way to set authentication method for the token endpoint.

**Context**
1. Per [RFC 6749 ](https://tools.ietf.org/html/rfc6749#section-2.3.1) not recommended to send credentials in the request-body:
> Including the client credentials in the request-body using the two
   parameters is NOT RECOMMENDED and SHOULD be limited to clients unable
   to directly utilize the HTTP Basic authentication scheme

2. Per  [RFC 7591](https://tools.ietf.org/html/rfc7591#section-2) there are 3 supported auth method `none ` (is omitted in the PR since it's only for public clients), `client_secret_post` and `client_secret_basic `.  With `client_secret_basic` as a default method
> If unspecified or omitted, the default is "client_secret_basic"

3. `node-oauth` has similar issuer unresolved since Jan 17, 2014 https://github.com/ciaranj/node-oauth/pull/316 , which is a dependency for [passport-oauth2](https://github.com/jaredhanson/passport-oauth2), so guess the internet is pretty broken ^^

I was trying to follow general code style at my best ;)
