### PR TITLE
Proposal for supporting user profiles

### DIFF
--- a/config/oauth.json
+++ b/config/oauth.json
@@ -2,6 +2,7 @@
   "23andme": {
     "authorize_url": "https://api.23andme.com/authorize",
     "access_url": "https://api.23andme.com/token",
+    "profile_url": "https://api.23andme.com/1/user",
     "oauth": 2,
     "scope_delimiter": " "
   },
@@ -9,11 +10,13 @@
     "request_url": "https://api.500px.com/v1/oauth/request_token",
     "authorize_url": "https://api.500px.com/v1/oauth/authorize",
     "access_url": "https://api.500px.com/v1/oauth/access_token",
+    "profil_url": "https://api.500px.com/v1/users",
     "oauth": 1
   },
   "acton": {
     "authorize_url": "https://restapi.actonsoftware.com/authorize",
     "access_url": "https://restapi.actonsoftware.com/token",
+    "profile_url": "https://restapi.actonsoftware.com/account",
     "oauth": 2
   },
   "acuityscheduling": {
@@ -30,6 +33,7 @@
   "amazon": {
     "authorize_url": "https://www.amazon.com/ap/oa",
     "access_url": "https://api.amazon.com/auth/o2/token",
+    "profile_url": "https://api.amazon.com/user/profile",
     "oauth": 2,
     "scope_delimiter": " ",
     "custom_parameters" : ["scope_data"]
@@ -37,6 +41,7 @@
   "angellist": {
     "authorize_url": "https://angel.co/api/oauth/authorize",
     "access_url": "https://angel.co/api/oauth/token",
+    "profile_url": "https://api.angel.co/me",
     "oauth": 2,
     "scope_delimiter": " "
   },
@@ -948,6 +953,7 @@
     "request_url": "https://api.twitter.com/oauth/request_token",
     "authorize_url": "https://api.twitter.com/oauth/authenticate",
     "access_url": "https://api.twitter.com/oauth/access_token",
+    "profile_url": "https://api.twitter.com/1.1/users/show.json",
     "oauth": 1
   },
   "typeform": {

--- a/config/reserved.json
+++ b/config/reserved.json
@@ -2,6 +2,7 @@
   "request_url",
   "authorize_url",
   "access_url",
+  "profile_url",
   "oauth",
   "scope_delimiter",
   "custom_parameters",
@@ -11,6 +12,7 @@
   "path",
   "transport",
   "state",
+  "profile",
 
   "key",
   "secret",

--- a/lib/consumer/express.js
+++ b/lib/consumer/express.js
@@ -1,11 +1,10 @@
-
 var express = require('express')
 var qs = require('qs')
 
 var config = require('../config')
 var oauth1 = require('../flow/oauth1')
 var oauth2 = require('../flow/oauth2')
-
+var getProfile = require('../profile');
 
 module.exports = function (_config) {
   var app = express()
@@ -67,6 +66,18 @@ module.exports = function (_config) {
     }
   }
 
+  var profile = (provider, session) => (data) => {
+    if (provider.profile === true) {
+      return getProfile(data, provider).then(profile => {
+        session.profile = profile
+
+        return data
+      })
+    }
+
+    return Promise.resolve(data)
+  }
+
   function connect (req, res) {
     var session = req.session.grant
     var provider = config.provider(app.config, session)
@@ -100,15 +111,18 @@ module.exports = function (_config) {
     var session = req.session.grant || {}
     var provider = config.provider(app.config, session)
     var response = transport(provider, res, session)
+    var setProfile = profile(provider, session);
 
     if (provider.oauth === 1) {
       oauth1.access(provider, session.request, req.query)
+        .then(setProfile)
         .then(response)
         .catch(response)
     }
 
     else if (provider.oauth === 2) {
       oauth2.access(provider, req.query, session)
+        .then(setProfile)
         .then(response)
         .catch(response)
     }

--- a/lib/profile.js
+++ b/lib/profile.js
@@ -4,29 +4,30 @@ const request = require('request-compose').extend({
 
 const requestOptions = {
   twitter (options, data) {
-    return {
-      ...options,
+    return Object.assign({
       qs: {user_id: data.raw && data.raw.user_id}
-    }
+    }, options);
   }
 }
 
 module.exports = (data, provider) => {
-  const options = {url: provider.profile_url}
-  const getOptions = requestOptions[provider.name] || (op => op)
-
-  if (provider.oauth === 1) {
-    options.oauth = {
-      consumer_key: provider.key,
-      consumer_secret: provider.secret,
-      token: data.access_token,
-      token_secret: data.access_secret,
+  try {
+    var options = {url: provider.profile_url}
+    var getOptions = requestOptions[provider.name] || (op => op)
+  
+    if (provider.oauth === 1) {
+      options.oauth = {
+        consumer_key: provider.key,
+        consumer_secret: provider.secret,
+        token: data.access_token,
+        token_secret: data.access_secret,
+      }
+    } else if (provider.oauth === 2) {
+      options.headers = {authorization: `Bearer ${data.access_token}`}
     }
-  } else if (provider.oauth === 2) {
-    options.headers = {authorization: `Bearer ${data.access_token}`}
+  
+    return request(getOptions(options, data)).then(({body}) => body);
+  } catch (error) {
+    return Promise.reject(error)
   }
-
-  const {body} = await request(getOptions(options))
-
-  return body
 }

--- a/lib/profile.js
+++ b/lib/profile.js
@@ -1,0 +1,32 @@
+const request = require('request-compose').extend({
+  Request: {oauth: require('request-oauth')}
+}).client
+
+const requestOptions = {
+  twitter (options, data) {
+    return {
+      ...options,
+      qs: {user_id: data.raw && data.raw.user_id}
+    }
+  }
+}
+
+module.exports = (data, provider) => {
+  const options = {url: provider.profile_url}
+  const getOptions = requestOptions[provider.name] || (op => op)
+
+  if (provider.oauth === 1) {
+    options.oauth = {
+      consumer_key: provider.key,
+      consumer_secret: provider.secret,
+      token: data.access_token,
+      token_secret: data.access_secret,
+    }
+  } else if (provider.oauth === 2) {
+    options.headers = {authorization: `Bearer ${data.access_token}`}
+  }
+
+  const {body} = await request(getOptions(options))
+
+  return body
+}


### PR DESCRIPTION
We are currently looking into a replacement for PassportJS for the latest version of [FeathersJS](https://feathersjs.com/) and it looks like Grant could help with many of the issues we were having around oAuth authentication while also allowing to finally support Koa and Hapi as the underlying HTTP framework 🚀 

This pull request is a prototype proposal to address #99 to allow profile gathering (which we would need to let people link oAuth to their Feathers user account).

Usage of this PR looks like this (after going through `connect/twitter` it will return the Twitter user profile as JSON):

```js
var express = require('express')
var session = require('express-session')
var grant = require('grant').express()
var config = {
  "defaults": {
    "protocol": "http",
    "host": "127.0.0.1:3000",
    "profile": true
  },
  "twitter": {
    "key": "twitter_key",
    "secret": "twitter_secret",
    "callback": "/hi"
  }
}


const app = express()
  .use(session({
    secret: 'grant',
    saveUninitialized: true,
    resave: true
  }))
  .use(grant(config))
  .get('/hi', async (req, res) => {
    const { profile = {} } = req.session.grant;
    
    res.json(profile)
  });

app.listen(3000)
```

As also mentioned in the issue, this could  be implemented as a separate module so before I go any further it would be great to get some feedback if this is a reasonable approach and wether or not it should be included in Grant or not. I'm well aware of the impact contributions like this can have when it comes to maintenance overhead, especially since it is difficult to test for all supported providers so I'd also be totally fine setting up a separate module with a list of tested and supported providers.
