### PR TITLE
feat: Allow to customize the /connect prefix

### DIFF
--- a/lib/consumer/express.js
+++ b/lib/consumer/express.js
@@ -7,11 +7,11 @@ var oauth1 = require('../flow/oauth1')
 var oauth2 = require('../flow/oauth2')
 
 
-module.exports = function (_config) {
+module.exports = function (_config, prefix = '/connect') {
   var app = express()
   app.config = config(_config)
 
-  app.use('/connect/:provider/:override?', (req, res) => {
+  app.use(`${prefix}/:provider/:override?`, (req, res) => {
     if (!req.session) {
       throw new Error('Grant: mount session middleware first')
     }

--- a/lib/consumer/express.js
+++ b/lib/consumer/express.js
@@ -7,8 +7,10 @@ var oauth1 = require('../flow/oauth1')
 var oauth2 = require('../flow/oauth2')
 
 
-module.exports = function (_config, prefix = '/connect') {
+module.exports = function (_config, _prefix) {
   var app = express()
+  var prefix = _prefix || '/connect';
+
   app.config = config(_config)
 
   app.use(`${prefix}/:provider/:override?`, (req, res) => {

--- a/lib/consumer/hapi.js
+++ b/lib/consumer/hapi.js
@@ -7,8 +7,9 @@ var oauth1 = require('../flow/oauth1')
 var oauth2 = require('../flow/oauth2')
 
 
-module.exports = function (_config, prefix = '/connect') {
+module.exports = function (_config, _prefix) {
   var app = {}
+  var prefix = _prefix || '/connect'
 
   function register (server, options, next) {
     app.config = config(Object.keys(options).length ? options : _config)

--- a/lib/consumer/hapi.js
+++ b/lib/consumer/hapi.js
@@ -7,7 +7,7 @@ var oauth1 = require('../flow/oauth1')
 var oauth2 = require('../flow/oauth2')
 
 
-module.exports = function (_config) {
+module.exports = function (_config, prefix = '/connect') {
   var app = {}
 
   function register (server, options, next) {
@@ -15,7 +15,7 @@ module.exports = function (_config) {
 
     server.route({
       method: ['GET', 'POST'],
-      path: '/connect/{provider}/{override?}',
+      path: `${prefix}/{provider}/{override?}`,
       handler: (req, res) => {
         if (!(req.session || req.yar)) {
           throw new Error('Grant: register session plugin first')
@@ -90,7 +90,7 @@ module.exports = function (_config) {
 
     server.route({
       method: 'GET',
-      path: '/connect/{provider}/callback',
+      path: `${prefix}/{provider}/callback`,
       handler: (req, res) => {
         var session = (req.session || req.yar).get('grant') || {}
         var provider = config.provider(app.config, session)

--- a/lib/consumer/hapi17.js
+++ b/lib/consumer/hapi17.js
@@ -6,7 +6,7 @@ var oauth1 = require('../flow/oauth1')
 var oauth2 = require('../flow/oauth2')
 
 
-module.exports = function (_config) {
+module.exports = function (_config, prefix = '/connect') {
   var app = {}
 
   function register (server, options) {
@@ -14,7 +14,7 @@ module.exports = function (_config) {
 
     server.route({
       method: ['GET', 'POST'],
-      path: '/connect/{provider}/{override?}',
+      path: `${prefix}/{provider}/{override?}`,
       handler: async (req, res) => {
         if (!(req.session || req.yar)) {
           throw new Error('Grant: register session plugin first')
@@ -90,7 +90,7 @@ module.exports = function (_config) {
 
     server.route({
       method: 'GET',
-      path: '/connect/{provider}/callback',
+      path: `${prefix}/{provider}/callback`,
       handler: async (req, res) => {
         var session = (req.session || req.yar).get('grant') || {}
         var provider = config.provider(app.config, session)

--- a/lib/consumer/hapi17.js
+++ b/lib/consumer/hapi17.js
@@ -6,8 +6,9 @@ var oauth1 = require('../flow/oauth1')
 var oauth2 = require('../flow/oauth2')
 
 
-module.exports = function (_config, prefix = '/connect') {
+module.exports = function (_config, _prefix) {
   var app = {}
+  var prefix = _prefix || '/connect'
 
   function register (server, options) {
     app.config = config(Object.keys(options).length ? options : _config)

--- a/lib/consumer/koa.js
+++ b/lib/consumer/koa.js
@@ -9,7 +9,7 @@ var oauth2 = require('../flow/oauth2')
 module.exports = function (_config, prefix = '\/connect') {
   var app = new Koa()
   // /:path*/${prefix}/:provider/:override?
-  var regex = new RegExp('^(?:\/([^\\\/]+?(?:\/[^\\\/]+?)*))?' + prefix + '\/([^\\\/]+?)(?:\/([^\\\/]+?))?(?:\/(?=$))?$', 'i')
+  var regex = new RegExp(`^(?:\/([^\\\/]+?(?:\/[^\\\/]+?)*))?${prefix}\/([^\\\/]+?)(?:\/([^\\\/]+?))?(?:\/(?=$))?$`, 'i')
 
   app.config = config(_config)
 

--- a/lib/consumer/koa.js
+++ b/lib/consumer/koa.js
@@ -6,8 +6,9 @@ var config = require('../config')
 var oauth1 = require('../flow/oauth1')
 var oauth2 = require('../flow/oauth2')
 
-module.exports = function (_config, prefix = '\/connect') {
+module.exports = function (_config, _prefix) {
   var app = new Koa()
+  var prefix = _prefix || '/connect'
   // /:path*/${prefix}/:provider/:override?
   var regex = new RegExp(`^(?:\/([^\\\/]+?(?:\/[^\\\/]+?)*))?${prefix}\/([^\\\/]+?)(?:\/([^\\\/]+?))?(?:\/(?=$))?$`, 'i')
 

--- a/lib/consumer/koa.js
+++ b/lib/consumer/koa.js
@@ -6,12 +6,11 @@ var config = require('../config')
 var oauth1 = require('../flow/oauth1')
 var oauth2 = require('../flow/oauth2')
 
-// /:path*/connect/:provider/:override?
-var regex = /^(?:\/([^\\/]+?(?:\/[^\\/]+?)*))?\/connect\/([^\\/]+?)(?:\/([^\\/]+?))?(?:\/(?=$))?$/i
-
-
-module.exports = function (_config) {
+module.exports = function (_config, prefix = '\/connect') {
   var app = new Koa()
+  // /:path*/${prefix}/:provider/:override?
+  var regex = new RegExp('^(?:\/([^\\\/]+?(?:\/[^\\\/]+?)*))?' + prefix + '\/([^\\\/]+?)(?:\/([^\\\/]+?))?(?:\/(?=$))?$', 'i')
+
   app.config = config(_config)
 
   app.use(function* (next) {

--- a/lib/consumer/koa2.js
+++ b/lib/consumer/koa2.js
@@ -9,7 +9,7 @@ var oauth2 = require('../flow/oauth2')
 module.exports = function (_config, prefix = '\/connect') {
   var app = new Koa()
   // /:path*/${prefix}/:provider/:override?
-  var regex = new RegExp('^(?:\/([^\\\/]+?(?:\/[^\\\/]+?)*))?' + prefix + '\/([^\\\/]+?)(?:\/([^\\\/]+?))?(?:\/(?=$))?$', 'i')
+  var regex = new RegExp(`^(?:\/([^\\\/]+?(?:\/[^\\\/]+?)*))?${prefix}\/([^\\\/]+?)(?:\/([^\\\/]+?))?(?:\/(?=$))?$`, 'i')
 
   app.config = config(_config)
 

--- a/lib/consumer/koa2.js
+++ b/lib/consumer/koa2.js
@@ -6,8 +6,9 @@ var config = require('../config')
 var oauth1 = require('../flow/oauth1')
 var oauth2 = require('../flow/oauth2')
 
-module.exports = function (_config, prefix = '\/connect') {
+module.exports = function (_config, prefix) {
   var app = new Koa()
+  var prefix = _prefix || '\/connect'
   // /:path*/${prefix}/:provider/:override?
   var regex = new RegExp(`^(?:\/([^\\\/]+?(?:\/[^\\\/]+?)*))?${prefix}\/([^\\\/]+?)(?:\/([^\\\/]+?))?(?:\/(?=$))?$`, 'i')
 

--- a/lib/consumer/koa2.js
+++ b/lib/consumer/koa2.js
@@ -6,12 +6,11 @@ var config = require('../config')
 var oauth1 = require('../flow/oauth1')
 var oauth2 = require('../flow/oauth2')
 
-// /:path*/connect/:provider/:override?
-var regex = /^(?:\/([^\\/]+?(?:\/[^\\/]+?)*))?\/connect\/([^\\/]+?)(?:\/([^\\/]+?))?(?:\/(?=$))?$/i
-
-
-module.exports = function (_config) {
+module.exports = function (_config, prefix = '\/connect') {
   var app = new Koa()
+  // /:path*/${prefix}/:provider/:override?
+  var regex = new RegExp('^(?:\/([^\\\/]+?(?:\/[^\\\/]+?)*))?' + prefix + '\/([^\\\/]+?)(?:\/([^\\\/]+?))?(?:\/(?=$))?$', 'i')
+
   app.config = config(_config)
 
   app.use(async (ctx, next) => {


### PR DESCRIPTION
This is a proposal to allow customizing the `connect/` prefix for the consumers. It should be fully backwards compatible.

This is probably not a common problem for green-field applications using Grant but the oAuth callbacks of many applications I am trying to migrate have been set up to point to `/auth/:name/callback` which is currently not possible to use with Grant. I'm hoping to introduce as few breaking changes as possible especially when it involves signing into the provider platform and changing things (instead of just code changes) so it would be great if this PR is accepted.