### PR TITLE
Fix a race condition where browsers redirect before session is persisted

### DIFF
--- a/lib/consumer/express.js
+++ b/lib/consumer/express.js
@@ -41,7 +41,7 @@ module.exports = function (_config) {
     connect(req, res)
   })
 
-  var transport = (provider, res, session) => (data) => {
+  var transport = (provider, req, res, session) => (data) => {
     if (!provider.callback) {
       res.end(qs.stringify(data))
     }
@@ -50,14 +50,16 @@ module.exports = function (_config) {
     }
     else if (provider.transport === 'session') {
       session.response = data
-      res.redirect(provider.callback)
+      req.session.save(() => {
+        res.redirect(provider.callback)
+      })
     }
   }
 
   function connect (req, res) {
     var session = req.session.grant
     var provider = config.provider(app.config, session)
-    var response = transport(provider, res, session)
+    var response = transport(provider, req, res, session)
 
     if (provider.oauth === 1) {
       oauth1.request(provider)
@@ -86,7 +88,7 @@ module.exports = function (_config) {
   function callback (req, res) {
     var session = req.session.grant || {}
     var provider = config.provider(app.config, session)
-    var response = transport(provider, res, session)
+    var response = transport(provider, req, res, session)
 
     if (provider.oauth === 1) {
       oauth1.access(provider, session.request, req.query)

--- a/lib/consumer/express.js
+++ b/lib/consumer/express.js
@@ -46,15 +46,18 @@ module.exports = function (_config) {
       res.end(qs.stringify(data))
     }
     else if (!provider.transport || provider.transport === 'querystring') {
-      res.redirect(`${provider.callback}?${qs.stringify(data)}`)
+      redirect(req, res, `${provider.callback}?${qs.stringify(data)}`)
     }
     else if (provider.transport === 'session') {
       session.response = data
-      req.session.save(() => {
-        res.redirect(provider.callback)
-      })
+      redirect(req, res, provider.callback)
     }
   }
+
+  var redirect = (req, res, url) =>
+    typeof req.session.save === 'function'
+      ? req.session.save(() => res.redirect(url))
+      : res.redirect(url)
 
   function connect (req, res) {
     var session = req.session.grant
@@ -66,7 +69,7 @@ module.exports = function (_config) {
         .then(({body}) => {
           session.request = body
           oauth1.authorize(provider, body)
-            .then((url) => res.redirect(url))
+            .then((url) => redirect(req, res, url))
             .catch(response)
         })
         .catch(response)
@@ -76,7 +79,7 @@ module.exports = function (_config) {
       session.state = provider.state
       session.nonce = provider.nonce
       oauth2.authorize(provider)
-        .then((url) => res.redirect(url))
+        .then((url) => redirect(req, res, url))
         .catch(response)
     }
 


### PR DESCRIPTION
As discussed in https://github.com/simov/grant/issues/121.

Note - this doesn't "double save" session if `resave: false` is used. Maybe it doesn't double save eve nif `resave: true`, but I'm not sure. So overally, I don't know of any downsides to this approach - only a big reliability upside.

Without this guard, grant is unreliable in that by calling res.redirect, even if express-session holds back the response from being fully completed, the redirect headers are sent to browsers and some browsers (e.g. Chrome) eagerly request the new page before session has been commited. This results in auth errors where the callback page can not authenticate the user since the session does not contain the oauth payload. I hope that's clear.

I'd argue this is a bug in express-session - that lib should potentially prevent redirect headers from being sent if session is not persisted. But I can see how that's probably more complicated.