### PR TITLE
make field names 'client_id', 'client_secret' configurable

### DIFF
--- a/config/oauth.json
+++ b/config/oauth.json
@@ -1033,7 +1033,8 @@
   "wechat": {
     "authorize_url": "https://open.weixin.qq.com/connect/oauth2/authorize",
     "access_url": "https://api.weixin.qq.com/sns/oauth2/access_token",
-    "oauth": 2
+    "oauth": 2,
+    "credentials_fields": {"key": "appid", "secret": "secret"}
   },
   "weekdone": {
     "authorize_url": "https://weekdone.com/oauth_authorize",

--- a/config/reserved.json
+++ b/config/reserved.json
@@ -5,6 +5,7 @@
   "oauth",
   "scope_delimiter",
   "custom_parameters",
+  "credentials_fields",
 
   "protocol",
   "host",

--- a/lib/config.js
+++ b/lib/config.js
@@ -84,7 +84,6 @@ var format = {
   ,
 
   custom_params: (provider) => {
-
     var keys = (provider.custom_parameters || [])
       .filter((key) =>
         !reserved.includes(key) &&
@@ -136,6 +135,18 @@ var format = {
 
     return Object.keys(overrides).length ? overrides : undefined
   },
+
+  credentials_fields: ({oauth, credentials_fields}) => {
+    var defaultFields = oauth === 1
+    ? {key: 'consumer_key', secret: 'consumer_secret'}
+
+    : oauth === 2
+    ? {key: 'client_id', secret: 'client_secret'}
+
+    : undefined
+
+    return credentials_fields || defaultFields
+  }
 
 }
 

--- a/lib/flow/oauth1.js
+++ b/lib/flow/oauth1.js
@@ -3,15 +3,25 @@ var qs = require('qs')
 var request = require('../client')
 var response = require('../response')
 
+var getCredentialsFields = (provider) => {
+  var keyField = 'consumer_key'
+  var secretField = 'consumer_secret'
+  if (provider.credentials_fields) {
+    keyField = provider.credentials_fields.key || keyField
+    secretField = provider.credentials_fields.secret || secretField
+  }
 
+  return {keyField, secretField}
+}
 exports.request = (provider) => new Promise((resolve, reject) => {
+  var {keyField, secretField} = getCredentialsFields(provider)
   var options = {
     method: 'POST',
     url: provider.request_url,
     oauth: {
       callback: provider.redirect_uri,
-      consumer_key: provider.key,
-      consumer_secret: provider.secret
+      [keyField]: provider.key,
+      [secretField]: provider.secret
     }
   }
   if (provider.etsy || provider.linkedin) {
@@ -23,7 +33,7 @@ exports.request = (provider) => new Promise((resolve, reject) => {
       'x-accept': 'application/x-www-form-urlencoded'
     }
     options.form = {
-      consumer_key: provider.key,
+      [keyField]: provider.key,
       redirect_uri: provider.redirect_uri,
       state: provider.state
     }
@@ -84,12 +94,13 @@ exports.access = (provider, req, authorize) => new Promise((resolve, reject) => 
       : {error: 'Grant: OAuth1 missing oauth_token parameter'})
     return
   }
+  var {keyField, secretField} = getCredentialsFields(provider)
   var options = {
     method: 'POST',
     url: provider.access_url,
     oauth: {
-      consumer_key: provider.key,
-      consumer_secret: provider.secret,
+      [keyField]: provider.key,
+      [secretField]: provider.secret,
       token: authorize.oauth_token,
       token_secret: req.oauth_token_secret,
       verifier: authorize.oauth_verifier
@@ -107,7 +118,7 @@ exports.access = (provider, req, authorize) => new Promise((resolve, reject) => 
       'x-accept': 'application/x-www-form-urlencoded'
     }
     options.form = {
-      consumer_key: provider.key,
+      [keyField]: provider.key,
       code: req.code
     }
   }

--- a/lib/flow/oauth2.js
+++ b/lib/flow/oauth2.js
@@ -7,8 +7,12 @@ var response = require('../response')
 
 exports.authorize = (provider) => new Promise((resolve) => {
   var url = provider.authorize_url
+  var keyField = 'client_id'
+  if (provider.credentials_fields) {
+    keyField = provider.credentials_fields.key || keyField
+  }
   var params = {
-    client_id: provider.key,
+    [keyField]: provider.key,
     response_type: 'code',
     redirect_uri: provider.redirect_uri,
     scope: provider.scope,
@@ -34,10 +38,6 @@ exports.authorize = (provider) => new Promise((resolve) => {
   if (provider.visualstudio) {
     params.response_type = 'Assertion'
   }
-  if (provider.wechat) {
-    params.appid = params.client_id
-    delete params.client_id
-  }
   if (provider.subdomain) {
     url = url.replace('[subdomain]', provider.subdomain)
   }
@@ -60,14 +60,21 @@ exports.access = (provider, authorize, session) => new Promise((resolve, reject)
     reject({error: {error: 'Grant: OAuth2 state mismatch'}})
     return
   }
+
+  var keyField = 'client_id'
+  var secretField = 'client_secret'
+  if (provider.credentials_fields) {
+    keyField = provider.credentials_fields.key || keyField
+    secretField = provider.credentials_fields.secret || secretField
+  }
   var options = {
     method: 'POST',
     url: provider.access_url,
     form: {
       grant_type: 'authorization_code',
       code: authorize.code,
-      client_id: provider.key,
-      client_secret: provider.secret,
+      [keyField]: provider.key,
+      [secretField]: provider.secret,
       redirect_uri: provider.redirect_uri
     }
   }
@@ -78,15 +85,15 @@ exports.access = (provider, authorize, session) => new Promise((resolve, reject)
     delete options.form
     options.qs = {
       code: authorize.code,
-      client_id: provider.key,
-      client_secret: provider.secret
+      [keyField]: provider.key,
+      [secretField]: provider.secret
     }
   }
   if (/ebay|fitbit|homeaway|hootsuite|reddit/.test(provider.name)
     || provider.token_endpoint_auth_method === 'client_secret_basic'
   ) {
-    delete options.form.client_id
-    delete options.form.client_secret
+    delete options.form[keyField]
+    delete options.form[secretField]
     options.auth = {user: provider.key, pass: provider.secret}
   }
   if (provider.qq) {
@@ -98,10 +105,6 @@ exports.access = (provider, authorize, session) => new Promise((resolve, reject)
     options.method = 'GET'
     options.qs = options.form
     delete options.form
-    options.qs.appid = options.qs.client_id
-    options.qs.secret = options.qs.client_secret
-    delete options.qs.client_id
-    delete options.qs.client_secret
   }
   if (provider.smartsheet) {
     delete options.form.client_secret

--- a/test/config.js
+++ b/test/config.js
@@ -251,6 +251,10 @@ describe('config', () => {
           key: 'key',
           secret: 'secret',
           custom_params: {team: 'github'},
+          credentials_fields: {
+            key: 'client_id',
+            secret: 'client_secret'
+          },
           overrides: {
             sub: {
               protocol: 'http',
@@ -261,7 +265,11 @@ describe('config', () => {
               custom_parameters: ['team'],
               key: 'key',
               secret: 'secret',
-              custom_params: {team: 'github'}
+              custom_params: {team: 'github'},
+              credentials_fields: {
+                key: 'client_id',
+                secret: 'client_secret'
+              },
             }
           }
         }
@@ -318,7 +326,11 @@ describe('config', () => {
           scope: 'openid',
           name: 'facebook',
           facebook: true,
-          redirect_uri: 'http://localhost:3000/connect/facebook/callback'
+          redirect_uri: 'http://localhost:3000/connect/facebook/callback',
+          credentials_fields: {
+            key: 'client_id',
+            secret: 'client_secret'
+          }
         }
       })
     })
@@ -340,7 +352,11 @@ describe('config', () => {
           scope: 'openid',
           name: 'facebook',
           facebook: true,
-          redirect_uri: 'http://localhost:3000/connect/facebook/callback'
+          redirect_uri: 'http://localhost:3000/connect/facebook/callback',
+          credentials_fields: {
+            key: 'client_id',
+            secret: 'client_secret'
+          }
         }
       })
     })
@@ -373,7 +389,11 @@ describe('config', () => {
           oauth: 2,
           dynamic: true,
           name: 'facebook',
-          facebook: true
+          facebook: true,
+          credentials_fields: {
+            key: 'client_id',
+            secret: 'client_secret'
+          }
         }
       )
     })


### PR DESCRIPTION
In most cases, the fields that transmit the provider `key` and `secret` during the Oauth flow are `client_id`, and `client_secret` (for Oauth2) respectively. However in some cases (e.g [wechat](https://github.com/simov/grant/blob/master/lib/flow/oauth2.js#L37-L39)), a different field name is required by the provider API. The way it is [currently handled](https://github.com/simov/grant/blob/master/lib/flow/oauth2.js#L37-L39) doesn't account for [Custom Providers](https://github.com/simov/grant#custom-providers) which may also have such exceptions.

To solve this problem, this PR adds the ability to set the field names that carry the values for `key`, and `secret`. So the provider options can be set [like this](https://github.com/ifedapoolarewaju/grant/commit/24ea6b5f4f7e36660e43885ffca630e40956d89b#diff-25c0f49628c5abd5a2f8c6c602783b56R1037) instead.

One particular use case that drove the submission of this PR is [Instagram's new Graph API](https://developers.facebook.com/docs/instagram-basic-display-api/reference/oauth-authorize). It uses the same Oauth API as the [old Instagram API](https://www.instagram.com/developer/authentication/), however both APIs require different field names for `client_id`, and `client_secret`:

#### old Instagram API requires fields client_id and client_secret
<img width="886" alt="Screenshot 2019-12-02 at 14 24 13" src="https://user-images.githubusercontent.com/8383781/69963012-8cd9d400-150f-11ea-94f8-a875224818ea.png">

#### new Instagram API requires fields app_id and app_secret
<img width="897" alt="Screenshot 2019-12-02 at 14 26 28" src="https://user-images.githubusercontent.com/8383781/69963114-cca0bb80-150f-11ea-932b-294e78a8fbf0.png">

So in order to support both APIs, Users must be able to set what field names they require to transmit their API credentials. So if I wanted to use the new [Instagram Graph API](https://developers.facebook.com/docs/instagram-basic-display-api/reference/oauth-authorize), I will set my Instagram Provider options like so:

```js
{
      protocol: 'https',
      // this next line is the most important line
      credentials_fields: {key: 'app_id', secret: 'app_secret'},  // specifying what fields to send credentials through
      scope: ['user_profile', 'user_media'],
      scope_delimiter: ","  // the new API uses commas as scope delimiter
}
```

