### PR TITLE
Add providers for CAS servers

### DIFF
--- a/config/oauth.json
+++ b/config/oauth.json
@@ -133,6 +133,16 @@
     "access_url": "https://api.createsend.com/oauth/token",
     "oauth": 2
   },
+  "casoauth2": {
+    "authorize_url": "https://[subdomain]/oauth2.0/authorize",
+    "access_url": "https://[subdomain]/oauth2.0/token",
+    "oauth": 2
+  },
+  "casoidc": {
+    "authorize_url": "https://[subdomain]/oidc/authorize",
+    "access_url": "https://[subdomain]/oidc/token",
+    "oauth": 2
+  },
   "cheddar": {
     "authorize_url": "https://api.cheddarapp.com/oauth/authorize",
     "access_url": "https://api.cheddarapp.com/oauth/token",


### PR DESCRIPTION
I am interested in using a [CAS](https://github.com/apereo/cas) server to authenticate to Strapi which is a framework that uses grant for authentication. CAS is an authentication server that supports oauth2 and OIDC and it can be installed on any organization's domain. I am new to grant and haven't used it yet, but do providers need to be defined in grant before I can use it? 

This PR adds a provider for CAS using both the oauth 2.0 and oidc endpoints. The [subdomain] in this case would possibly include a context such as `/cas` after the domain so an OIDC authorize url might be `https://www.organization.com/cas/oidc/authorize` with `subdomain=https://www.organization.com/cas`

Oauth2.0 - https://apereo.github.io/cas/development/installation/OAuth-OpenId-Authentication.html#endpoints
OIDC - https://apereo.github.io/cas/development/installation/OIDC-Authentication.html#endpoints

I want to confirm that I am going down the right path before trying to test this. 

Thanks.