### PR TITLE
Add support for AWS Cognito

### DIFF
--- a/config/oauth.json
+++ b/config/oauth.json
@@ -143,6 +143,12 @@
     "access_url": "https://app.clio.com/oauth/token",
     "oauth": 2
   },
+  "cognito": {
+    "authorize_url": "https://[subdomain]/authorize",
+    "access_url": "https://[subdomain]/token",
+    "oauth": 2,
+    "scope_delimiter": " "
+  },
   "coinbase": {
     "authorize_url": "https://www.coinbase.com/oauth/authorize",
     "access_url": "https://www.coinbase.com/oauth/token",


### PR DESCRIPTION
Add support for [AWS Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-userpools-server-contract-reference.html).

The provider has the following quirks.

The default endpoints are as follows:

```
https://cognito-idp.{aws-region}.amazonaws.com/{userPoolId}/authorize
https://cognito-idp.{aws-region}.amazonaws.com/{userPoolId}/token
```

However, if a User Pool domain is [configured](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-assign-domain.html), the endpoints becomes:

```
https://{domain-prefix}.{aws-region}.amazoncognito.com/oauth2/authorize
https://{domain-prefix}.{aws-region}.amazoncognito.com/oauth2/token
```
