### PR TITLE
handle session dynamic callback

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -105,6 +105,9 @@ var transport = ({provider, input, input:{params, state, session}, output}) => (
     ? output
 
     : (!provider.transport || provider.transport === 'querystring')
+    ? (session.dynamic.callback) 
+    
+    : `${session.dynamic.callback || '/'}?${qs.stringify(output)}`
     ? `${provider.callback || '/'}?${qs.stringify(output)}`
 
     : provider.transport === 'session'


### PR DESCRIPTION
I found  this issue while working with strapi so I do request other  maintainers and contributors to review this PR thoroughly 

On Strapi, for facebook provider

## Observed behavior

1. front end makes a call to http://localhost:1337/connect/facebook?callback=http://newdomain.com/auth with custom callback 'http://newdomain.com/auth'
2. grant/strapi picks up the custom callback url(http://newdomain.com/auth) from the custom callback url and is stored in session
3. grant provides the 'location' and strapi redirects to facebook for authentication
4. facebook redirects back to strapi at /connect/facebook/callback
5. strapi authenticates the  user
6. grant still has the custom callback stored in session but still redirects to http://olddomain.com/auth?access_token=xyz (default callback)

##  Expected behavior

Assuming that callback parameter provided in http://localhost:1337/connect/facebook?callback=http://newdomain.com
is the callback for after strapi authentication is completed AKA frontend redirect URI

1. front end makes a call to http://localhost:1337/connect/facebook?callback=http://newdomain.com with custom callback 'http://newdomain.com'
2. grant/strapi picks up the custom callback url(http://newdomain.com) from the url and is stored in session
3. grant provides the 'location' and strapi redirects to facebook for authentication
4. facebook redirects back to strapi at /connect/facebook/callback
5. strapi authenticates the  user
**6. grant uses the custom callback stored in session (provided by user in step 1) and redirects to http://newdomain.com/auth?access_token=xyz**

and that's all  this PR does 
- In the grant pipe checks if the session has a dynamic callback.. 
- if there is a dynamic callback in session, it  uses that instead of the default callback

