### PR TITLE
add default cas profile url

### DIFF
--- a/config/profile.json
+++ b/config/profile.json
@@ -72,7 +72,7 @@
     "profile_url": "https://api.createsend.com/api/v3.1/clients.json"
   },
   "cas": {
-    "profile_url": ""
+    "profile_url": "https://[subdomain]/oidc/profile"
   },
   "cheddar": {
     "profile_url": "https://api.cheddarapp.com/v1/me"


### PR DESCRIPTION
Might as well set the default URL for getting profile for the cas oidc provider.

https://apereo.github.io/cas/development/installation/OAuth-OpenId-Authentication.html#endpoints
