### PR TITLE
Allow for a little more clock skew

### DIFF
--- a/lib/flow/oauth2.js
+++ b/lib/flow/oauth2.js
@@ -115,8 +115,8 @@ exports.access = ({request:client}) => async ({provider, input, input:{query, bo
         aud: provider.access_url,
         jti: crypto.randomBytes(20).toString('hex'),
         exp: Math.round(Date.now() / 1000) + 300,
-        iat: Math.round(Date.now() / 1000),
-        nbf: Math.round(Date.now() / 1000)
+        iat: Math.round(Date.now() / 1000) - 120,
+        nbf: Math.round(Date.now() / 1000) - 120
       },
       secret
     })


### PR DESCRIPTION
We've got a virtualized environment that is susceptible to clock skew and have experienced JWT's `nbf` being in the future and rejected. It would increase the robustness if clock skew was accounted for in both directions of time. I'm not married to 120 seconds but I thought it was a good starting point. Kerberos has similar clock skew allowances.