### PR TITLE
fix(profile): twitch profile headers

### DIFF
--- a/lib/profile.js
+++ b/lib/profile.js
@@ -92,6 +92,6 @@ var custom = {
   tumblr: ({output}) => ({qs: {api_key: output.access_token}}),
   vk: ({output}) => ({qs: {access_token: output.access_token, v: '5.103'}}),
   weibo: ({output}) => ({qs: {access_token: output.access_token, uid: output.raw.uid}}),
-  twitch: ({provider, output}) => ({headers: {'client-id': provider.client_id, 'Authorization': `Bearer ${output.access_token}`}}),
+  twitch: ({provider, output}) => ({headers: {'client-id': provider.key, authorization: `Bearer ${output.access_token}`}}),
   twitter: ({output}) => ({qs: {user_id: output.raw.user_id}}),
 }

--- a/lib/profile.js
+++ b/lib/profile.js
@@ -92,5 +92,6 @@ var custom = {
   tumblr: ({output}) => ({qs: {api_key: output.access_token}}),
   vk: ({output}) => ({qs: {access_token: output.access_token, v: '5.103'}}),
   weibo: ({output}) => ({qs: {access_token: output.access_token, uid: output.raw.uid}}),
+  twitch: ({provider, output}) => ({headers: {'client-id': provider.client_id, 'Authorization': `Bearer ${output.access_token}`}}),
   twitter: ({output}) => ({qs: {user_id: output.raw.user_id}}),
 }


### PR DESCRIPTION
Add the client-id header to fetch the Twitch profile in the response.

Before:
```
"profile": {
  "error": {
    "error": "Unauthorized",
    "status": 401,
    "message": "Client ID and OAuth token do not match"
  }
}
```

After:
```
"profile": {
  "data": [
    {
      "id": "120234353",
      ...
    }
  ]
}
```