### PR TITLE
Set sane scope default  (scope=["openid"]) for provider "microsoft"

### DIFF
--- a/config/oauth.json
+++ b/config/oauth.json
@@ -630,7 +630,8 @@
     "authorize_url": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
     "access_url": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
     "oauth": 2,
-    "scope_delimiter": " "
+    "scope_delimiter": " ",
+    "scope" : ["openid"]
   },
   "mixcloud": {
     "authorize_url": "https://www.mixcloud.com/oauth/authorize",


### PR DESCRIPTION
Without the minimally required `openid` scope there will always be an error.