### PR TITLE
remove dynamic import statements

### DIFF
--- a/grant.js
+++ b/grant.js
@@ -22,8 +22,7 @@ function grant ({handler, ...rest}) {
 }
 
 grant.express = (options) => {
-  var version = 4
-  var handler = require(`./lib/handler/express-${version}`)
+  var handler = require('./lib/handler/express-4')
   return options ? handler(options) : handler
 }
 

--- a/grant.js
+++ b/grant.js
@@ -2,10 +2,16 @@
 function grant ({handler, ...rest}) {
   if (handler === 'express') {
     var version = 4
+    return require('./lib/handler/express-4')(rest)
   }
   else if (handler === 'koa') {
-    var version =
-      parseInt(require('koa/package.json').version.split('.')[0]) >= 2 ? 2 : 1
+    if (parseInt(require('koa/package.json').version.split('.')[0]) >= 2) {
+      return require('./lib/handler/koa-2')(rest)
+    }
+    else {
+      return require('./lib/handler/koa-1')(rest)
+    }
+  
   }
   else if (handler === 'hapi') {
     try {
@@ -15,10 +21,14 @@ function grant ({handler, ...rest}) {
       var pkg = require('hapi/package.json')
     }
     var version = parseInt(pkg.version.split('.')[0]) >= 17 ? 17 : 16
+    if (version >= 17) {
+      return require('./lib/handler/hapi-17')(rest)
+    }
+    else {
+      return require('./lib/handler/hapi-16')(rest)
+    }
+
   }
-  return version
-    ? require(`./lib/handler/${handler}-${version}`)(rest)
-    : require(`./lib/handler/${handler}`)(rest)
 }
 
 grant.express = (options) => {
@@ -29,7 +39,12 @@ grant.express = (options) => {
 grant.koa = (options) => {
   var version =
     parseInt(require('koa/package.json').version.split('.')[0]) >= 2 ? 2 : 1
-  var handler = require(`./lib/handler/koa-${version}`)
+  if (version >= 2) {
+    var handler = require('./lib/handler/koa-2')
+  }
+  else {
+    var handler = require('./lib/handler/koa-1')
+  }
   return options ? handler(options) : handler
 }
 
@@ -41,19 +56,43 @@ grant.hapi = (options) => {
     var pkg = require('hapi/package.json')
   }
   var version = parseInt(pkg.version.split('.')[0]) >= 17 ? 17 : 16
-  var handler = require(`./lib/handler/hapi-${version}`)
+  if (version >= 17) {
+    var handler = require('./lib/handler/hapi-17')(rest)
+  }
+  else {
+    var handler = require('./lib/handler/hapi-16')(rest)
+  }
   return options ? handler(options) : handler
 }
 
-;[
-  'fastify', 'curveball',
-  'node', 'aws', 'azure', 'gcloud', 'vercel'
-].forEach((provider) => {
-  grant[provider] = (options) => {
-    var handler = require(`./lib/handler/${provider}`)
-    return options ? handler(options) : handler
-  }
-})
+grant['fastify'] = (options) => {
+  var handler = require('./lib/handler/fastify')
+  return options ? handler(options) : handler
+}
+grant['curveball'] = (options) => {
+  var handler = require('./lib/handler/curveball')
+  return options ? handler(options) : handler
+}
+grant['node'] = (options) => {
+  var handler = require('./lib/handler/node')
+  return options ? handler(options) : handler
+}
+grant['aws'] = (options) => {
+  var handler = require('./lib/handler/aws')
+  return options ? handler(options) : handler
+}
+grant['azure'] = (options) => {
+  var handler = require('./lib/handler/azure')
+  return options ? handler(options) : handler
+}
+grant['gcloud'] = (options) => {
+  var handler = require('./lib/handler/gcloud')
+  return options ? handler(options) : handler
+}
+grant['vercel'] = (options) => {
+  var handler = require('./lib/handler/vercel')
+  return options ? handler(options) : handler
+}
 
 grant.default = grant
 module.exports = grant


### PR DESCRIPTION
fixes #231 
## Background 
Importing from paths generated at runtime breaks
parcel, see (parcel-bundler/parcel#4031),
or esbuild, see (evanw/esbuild#480).

## Summary
replace dynamic import statements with hardcoded ones.
