### PR TITLE
use 'any' instead of 'object' on type definitions

### DIFF
--- a/grant.d.ts
+++ b/grant.d.ts
@@ -122,7 +122,7 @@ export interface GrantProvider {
   /**
    * Static configuration overrides for a provider
    */
-  overrides?: object
+  overrides?: any
   /**
    * Configuration keys that can be overridden dynamically over HTTP
    */
@@ -161,7 +161,7 @@ export interface GrantProvider {
   /**
    * Custom authorization parameters and their values
    */
-  custom_params?: object
+  custom_params?: any
   /**
    * String to embed into the authorization server URLs
    */
@@ -169,11 +169,11 @@ export interface GrantProvider {
   /**
    * Public PEM or JWK
    */
-  public_key?: string | object
+  public_key?: string | any
   /**
    * Private PEM or JWK
    */
-  private_key?: string | object
+  private_key?: string | any
   /**
    * Absolute redirect URL of the OAuth app
    */
@@ -199,7 +199,7 @@ export interface GrantSessionConfig {
   /**
    * Cookie options
    */
-  cookie?: object
+  cookie?: any
   /**
    * Session store
    */
@@ -213,11 +213,11 @@ export interface GrantSessionStore {
   /**
    * Get item from session store
    */
-  get: (sid: string) => object
+  get: (sid: string) => any
   /**
    * Set item in session store
    */
-  set: (sid: string, json: object) => void
+  set: (sid: string, json: any) => void
   /**
    * Remove item from session store
    */
@@ -233,7 +233,7 @@ export interface GrantInstance {
   /**
    * Grant instance configuration
    */
-  config: object
+  config: any
 }
 
 /**
@@ -243,11 +243,11 @@ export type GrantHandler = (
   /**
    * Request object
    */
-  req: object,
+  req: any,
   /**
    * Response object
    */
-  res?: object,
+  res?: any,
   /**
    * Grant dynamic state overrides
    */
@@ -265,7 +265,7 @@ export interface GrantHandlerResult {
   /**
    * HTTP redirect
    */
-  redirect?: object | boolean
+  redirect?: any | boolean
   /**
    * Grant response
    */
@@ -289,7 +289,7 @@ export interface GrantSession {
   /**
    * The dynamic override configuration passed to this authorization
    */
-  dynamic?: object
+  dynamic?: any
   /**
    * OAuth 2.0 state string that was generated
    */
@@ -335,19 +335,19 @@ export interface GrantResponse {
   /**
    * Raw response data
    */
-  raw?: object
+  raw?: any
   /**
    * Parsed id_token JWT
    */
-  jwt?: object
+  jwt?: any
   /**
    * User profile response
    */
-  profile?: object
+  profile?: any
   /**
    * Error response
    */
-  error?: object
+  error?: any
 }
 
 // ----------------------------------------------------------------------------
@@ -363,11 +363,11 @@ export type KoaMiddleware = (ctx: any, next?: () => Promise<void>) => Promise<vo
 /**
  * Hapi middleware
  */
-export type HapiMiddleware = {register: (server: any, options?: object) => void, pkg: object}
+export type HapiMiddleware = {register: (server: any, options?: any) => void, pkg: any}
 /**
  * Fastify middleware
  */
-export type FastifyMiddleware = (server: any, options: object, next: () => void) => void
+export type FastifyMiddleware = (server: any, options: any, next: () => void) => void
 /**
  * Curveball middleware
  */

--- a/grant.d.ts
+++ b/grant.d.ts
@@ -122,7 +122,9 @@ export interface GrantProvider {
   /**
    * Static configuration overrides for a provider
    */
-  overrides?: any
+  overrides?: {
+    [key: string]: Omit<GrantProvider, 'overrides'>
+  }
   /**
    * Configuration keys that can be overridden dynamically over HTTP
    */
@@ -161,7 +163,7 @@ export interface GrantProvider {
   /**
    * Custom authorization parameters and their values
    */
-  custom_params?: any
+  custom_params?: obj
   /**
    * String to embed into the authorization server URLs
    */
@@ -169,11 +171,11 @@ export interface GrantProvider {
   /**
    * Public PEM or JWK
    */
-  public_key?: string | any
+  public_key?: string | obj
   /**
    * Private PEM or JWK
    */
-  private_key?: string | any
+  private_key?: string | obj
   /**
    * Absolute redirect URL of the OAuth app
    */
@@ -199,7 +201,7 @@ export interface GrantSessionConfig {
   /**
    * Cookie options
    */
-  cookie?: any
+  cookie?: obj
   /**
    * Session store
    */
@@ -213,11 +215,11 @@ export interface GrantSessionStore {
   /**
    * Get item from session store
    */
-  get: (sid: string) => any
+  get: (sid: string) => obj
   /**
    * Set item in session store
    */
-  set: (sid: string, json: any) => void
+  set: (sid: string, json: obj) => void
   /**
    * Remove item from session store
    */
@@ -233,7 +235,7 @@ export interface GrantInstance {
   /**
    * Grant instance configuration
    */
-  config: any
+  config: obj
 }
 
 /**
@@ -265,7 +267,7 @@ export interface GrantHandlerResult {
   /**
    * HTTP redirect
    */
-  redirect?: any | boolean
+  redirect?: obj | boolean
   /**
    * Grant response
    */
@@ -289,7 +291,7 @@ export interface GrantSession {
   /**
    * The dynamic override configuration passed to this authorization
    */
-  dynamic?: any
+  dynamic?: GrantProvider & obj
   /**
    * OAuth 2.0 state string that was generated
    */
@@ -335,20 +337,29 @@ export interface GrantResponse {
   /**
    * Raw response data
    */
-  raw?: any
+  raw?: obj
   /**
    * Parsed id_token JWT
    */
-  jwt?: any
+  jwt?: {
+    id_token?: {header: obj, payload: obj, signature: string}
+  }
   /**
    * User profile response
    */
-  profile?: any
+  profile?: obj
   /**
    * Error response
    */
-  error?: any
+  error?: obj
 }
+
+// ----------------------------------------------------------------------------
+
+/**
+ * Object with unknown keys
+ */
+type obj = {[key: string]: any}
 
 // ----------------------------------------------------------------------------
 
@@ -363,11 +374,11 @@ export type KoaMiddleware = (ctx: any, next?: () => Promise<void>) => Promise<vo
 /**
  * Hapi middleware
  */
-export type HapiMiddleware = {register: (server: any, options?: any) => void, pkg: any}
+export type HapiMiddleware = {register: (server: any, options?: obj) => void, pkg: obj}
 /**
  * Fastify middleware
  */
-export type FastifyMiddleware = (server: any, options: any, next: () => void) => void
+export type FastifyMiddleware = (server: any, options: obj, next: () => void) => void
 /**
  * Curveball middleware
  */

--- a/grant.d.ts
+++ b/grant.d.ts
@@ -163,7 +163,7 @@ export interface GrantProvider {
   /**
    * Custom authorization parameters and their values
    */
-  custom_params?: obj
+  custom_params?: any
   /**
    * String to embed into the authorization server URLs
    */
@@ -171,11 +171,11 @@ export interface GrantProvider {
   /**
    * Public PEM or JWK
    */
-  public_key?: string | obj
+  public_key?: any
   /**
    * Private PEM or JWK
    */
-  private_key?: string | obj
+  private_key?: any
   /**
    * Absolute redirect URL of the OAuth app
    */
@@ -201,7 +201,7 @@ export interface GrantSessionConfig {
   /**
    * Cookie options
    */
-  cookie?: obj
+  cookie?: any
   /**
    * Session store
    */
@@ -215,11 +215,11 @@ export interface GrantSessionStore {
   /**
    * Get item from session store
    */
-  get: (sid: string) => obj
+  get: (sid: string) => any
   /**
    * Set item in session store
    */
-  set: (sid: string, json: obj) => void
+  set: (sid: string, json: any) => void
   /**
    * Remove item from session store
    */
@@ -235,7 +235,7 @@ export interface GrantInstance {
   /**
    * Grant instance configuration
    */
-  config: obj
+  config: any
 }
 
 /**
@@ -267,7 +267,7 @@ export interface GrantHandlerResult {
   /**
    * HTTP redirect
    */
-  redirect?: obj | boolean
+  redirect?: any
   /**
    * Grant response
    */
@@ -291,7 +291,7 @@ export interface GrantSession {
   /**
    * The dynamic override configuration passed to this authorization
    */
-  dynamic?: GrantProvider & obj
+  dynamic?: any
   /**
    * OAuth 2.0 state string that was generated
    */
@@ -337,29 +337,22 @@ export interface GrantResponse {
   /**
    * Raw response data
    */
-  raw?: obj
+  raw?: any
   /**
    * Parsed id_token JWT
    */
   jwt?: {
-    id_token?: {header: obj, payload: obj, signature: string}
+    id_token?: {header: any, payload: any, signature: string}
   }
   /**
    * User profile response
    */
-  profile?: obj
+  profile?: any
   /**
    * Error response
    */
-  error?: obj
+  error?: any
 }
-
-// ----------------------------------------------------------------------------
-
-/**
- * Object with unknown keys
- */
-type obj = {[key: string]: any}
 
 // ----------------------------------------------------------------------------
 
@@ -374,11 +367,11 @@ export type KoaMiddleware = (ctx: any, next?: () => Promise<void>) => Promise<vo
 /**
  * Hapi middleware
  */
-export type HapiMiddleware = {register: (server: any, options?: obj) => void, pkg: obj}
+export type HapiMiddleware = {register: (server: any, options?: any) => void, pkg: any}
 /**
  * Fastify middleware
  */
-export type FastifyMiddleware = (server: any, options: obj, next: () => void) => void
+export type FastifyMiddleware = (server: any, options: any, next: () => void) => void
 /**
  * Curveball middleware
  */


### PR DESCRIPTION
The reason for this change is because `object` is very restrictive, and you can't really access the contents of a `GrantResponse` freely, for example:

```typescript
export interface GrantResponse {
  profile?: object
}

const grant: GrantResponse = {};
const id = grant.profile?.id; // Error: Property 'id' does not exist on type 'object'.(2339)
```

TypeScript playground URL: https://www.typescriptlang.org/play?#code/PQKhFgCgAIWhxATgQwHYBdqIKYGcAOA9qrtlLMFNgB5GKYCWG2iAZsgMbYIoYBKeIiW4BvclmQB3APwAuaIQBGAK2wd04-IkKsGAG2xyFKtRsgBfKFA7FcmAOa908pGnQCCt7gF5oI8wDcVpA2JIwAJtC+jm4AdFo6+oaxDOEBQA