### PR TITLE
feat: change withings auth according to breaking changes

### DIFF
--- a/config/oauth.json
+++ b/config/oauth.json
@@ -1065,7 +1065,7 @@
   },
   "withings": {
     "authorize_url": "https://account.withings.com/oauth2_user/authorize2",
-    "access_url": "https://account.withings.com/oauth2/token",
+    "access_url": "https://wbsapi.withings.net/v2/oauth2",
     "oauth": 2
   },
   "wordpress": {

--- a/lib/flow/oauth2.js
+++ b/lib/flow/oauth2.js
@@ -65,7 +65,7 @@ exports.access = ({request:client}) => async ({provider, input, input:{query, bo
       ? query : {error: 'Grant: OAuth2 missing code parameter'}
     return {provider, input, output}
   }
-  else if (session.state && (query.state !== session.state)) {
+  else if ((query.state && session.state) && (query.state !== session.state)) {
     var output = {error: 'Grant: OAuth2 state mismatch'}
     return {provider, input, output}
   }
@@ -79,6 +79,9 @@ exports.access = ({request:client}) => async ({provider, input, input:{query, bo
       client_secret: provider.secret,
       redirect_uri: provider.redirect_uri
     }
+  }
+  if (provider.withings) {
+    options.form.action = 'requesttoken'
   }
   if (provider.pkce) {
     options.form.code_verifier = session.code_verifier
@@ -182,9 +185,13 @@ exports.access = ({request:client}) => async ({provider, input, input:{query, bo
     if (provider.intuit) {
       output.realmId = query.realmId
     }
+    if (provider.withings) {
+      output = output.body;
+    }
   }
   catch (err) {
     var output = {error: err.body || err.message}
   }
+  console.log('options', options, output);
   return {provider, input, output}
 }

--- a/lib/flow/oauth2.js
+++ b/lib/flow/oauth2.js
@@ -192,6 +192,5 @@ exports.access = ({request:client}) => async ({provider, input, input:{query, bo
   catch (err) {
     var output = {error: err.body || err.message}
   }
-  console.log('options', options, output);
   return {provider, input, output}
 }


### PR DESCRIPTION
Withings change their auth API. In 6 months it would be not responding. I've made some changes to make the new API work as expected.
https://support.withings.com/hc/en-us/articles/360016745358--BREAKING-Deprecating-access-and-refresh-tokens-endpoints