### PR TITLE
Usage example with stateless fastify-secure-session

### DIFF
--- a/examples/session-store/fastify-secure-session.js
+++ b/examples/session-store/fastify-secure-session.js
@@ -1,0 +1,27 @@
+
+var fastify = require('fastify')
+var session = require('fastify-secure-session')
+var grant = require('../../').fastify()
+
+
+fastify()
+  .register(session, {
+    secret: '01234567890123456789012345678912',
+    salt: 'mOXbPOPAcEb8hMDH',
+    cookie: { path: '/', httpOnly: true }
+  })
+  .addHook('onRequest', (req, res, next) => {
+    Object.defineProperty(req.session, 'grant', {
+      get: () => req.session.get('grant'),
+      set: (value) => req.session.set('grant', value)
+    })
+    next()
+  })
+  .register(grant(require('./config')))
+  .route({method: 'GET', path: '/hello', handler: async (req, res) => {
+    res.send(JSON.stringify(req.session.grant.response, null, 2))
+  }})
+  .route({method: 'GET', path: '/hi', handler: async (req, res) => {
+    res.send(JSON.stringify(req.session.grant.response, null, 2))
+  }})
+  .listen(3000)

--- a/examples/session-store/package.json
+++ b/examples/session-store/package.json
@@ -21,6 +21,7 @@
     "express-session": "^1.17.1",
     "fastify": "^3.3.0",
     "fastify-cookie": "^4.0.2",
+    "fastify-secure-session": "^2.3.1",
     "fastify-session": "^5.0.0",
     "koa": "^2.11.0",
     "koa-generic-session": "^2.0.4",


### PR DESCRIPTION
Life-saving project. Thank you so much!

Even though I was able to get started within minutes, I wanted to share another example: How to use grant with `fastify-secure-session` instead of `fastify-session`.

`fastify-secure-session` doesn't require nor provides a server-side store as it's designed to work stateless, which is super helpful in distributed systems. The caveat compared to most default implementations is that you can't modify `req.session` properties directly but have to use `req.session.get()` and `req.session.set()` methods.

Being close to submit a PR for a modification of your handler in `lib/handler/fastify.js` to support getters/setters around lines 32ff:

```js
      var {location, session, state} = await grant({
        method: req.method,
        params: req.params,
        query: qs.parse(req.query),
        body: qs.parse(req.body),
        state: req.grant,
        session: typeof req.session.get === 'function'? req.session.get('grant'):req.session.grant,
      })

      if(typeof req.session.set === 'function'){
        req.session.set('grant', session)
      }else{
        req.session.grant = session
      }
```

...well, in general, I try to act as least obstructive as possible, so I decided to provide another option without the need for code-change, as fastify provides us with hooks and encapsulation to design or extend most aspects of any given module/plugin. 

So in short: Applied another hook to define `req.session.grant` as getter/setter was enough to get me going:

```js
  fastify.addHook('onRequest', (req, res, next) => {
    Object.defineProperty(req.session, 'grant', {
      get: () => req.session.get('grant'),
      set: (value) => req.session.set('grant', value)
    })
    next()
  })
```

Happy to share these thoughts and an example :)