### PR TITLE
Add crossid provider.

### DIFF
--- a/config/oauth.json
+++ b/config/oauth.json
@@ -1147,5 +1147,11 @@
     "access_url": "https://zoom.us/oauth/token",
     "oauth": 2,
     "scope_delimiter": " "
+  },
+  "crossid": {
+    "authorize_url": "https://[subdomain].crossid.io/oauth2/auth",
+    "access_url": "https://[subdomain].crossid.io/oauth2/token",
+    "oauth": 2,
+    "scope_delimiter": " "
   }
 }

--- a/config/profile.json
+++ b/config/profile.json
@@ -616,5 +616,8 @@
   },
   "zoom": {
     "profile_url": "https://api.zoom.us/v2/users/me"
+  },
+  "crossid": {
+    "profile_url": "https://[subdomain].crossid.io/oauth2/userinfo"
   }
 }


### PR DESCRIPTION
Add the `crossid` provider

working configuration:

```json
{
    "defaults": {
      "origin": "http://localhost:3005",
      "transport": "session",
      "state": true
    },
    "crossid": {
      "subdomain": "acme",
      "key": "my_client_id",
      "secret": "my_client_secret",
      "scope": [
        "openid"
      ],
      "callback": "/hello",
      "response": ["tokens", "raw", "profile"]
    }
  }
```