### PR TITLE
Use new token endpoint for Google oauth

### DIFF
--- a/config/oauth.json
+++ b/config/oauth.json
@@ -459,8 +459,8 @@
     "oauth": 1
   },
   "google": {
-    "authorize_url": "https://accounts.google.com/o/oauth2/auth",
-    "access_url": "https://accounts.google.com/o/oauth2/token",
+    "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
+    "access_url": "https://oauth2.googleapis.com/token",
     "oauth": 2,
     "scope_delimiter": " "
   },


### PR DESCRIPTION
Hello folks,

Suggesting an update of `access_url` (token endpoint) for provider google since it was updated a few years ago. It should not break the integrations (I did some basic testing and everything works fine), however new endpoint is OpenIDConnect compliant and allows discovery, I also faced problems to refresh the token using `refresh_token` with the old endpoint. 

New endpoint is also used in [actual docs](https://developers.google.com/identity/protocols/oauth2/web-server#exchange-authorization-code).