### PR TITLE
feat: support electron

### DIFF
--- a/examples/electron.js
+++ b/examples/electron.js
@@ -1,0 +1,43 @@
+const { app } = require('electron'),
+  electron = require('electron'),
+  grant = require('grant');
+
+const baseUrl = 'http://grant',
+  grantMiddleware = grant({});
+
+electron.app.whenReady()
+  .then(() => {
+    const prefix = `${baseUrl}${grantMiddleware.config.defaults.prefix}/`,
+      win = new electron.BrowserWindow({
+        width: 800,
+        height: 600
+      });
+    win.loadURL(`${prefix}hcp`);
+
+    const redirectURLs = {};
+    win.webContents.session.webRequest.onBeforeRequest(async (details, respond) => {
+      if (details.url.startsWith(prefix)) {
+        const { redirect, response, provider } = await grantMiddleware(details, respond);
+        if (redirect) {
+          const redirectURL = new URL(redirect).searchParams.get('redirect_uri');
+          if (redirectURL) {
+            redirectURLs[redirectURL] = `${prefix}${provider}/callback`;
+          }
+        }
+        if (response) {
+          console.log(response);
+          app.quit();
+        }
+        return;
+      }
+      const { origin, pathname, search, hash } = new URL(details.url),
+        redirectURL = redirectURLs[`${origin}${pathname}`];
+      if (redirectURL) {
+        respond({ redirectURL: `${redirectURL}${search}${hash}` });
+      } else {
+        respond({});
+      }
+    });
+    return win;
+  })
+  .catch(() => {});

--- a/grant.d.ts
+++ b/grant.d.ts
@@ -12,7 +12,7 @@ export interface GrantOptions {
    * Handler name
    */
   handler?: 'express' | 'koa' | 'hapi' | 'fastify' | 'curveball' |
-            'node' | 'aws' | 'azure' | 'gcloud' | 'vercel'
+            'node' | 'aws' | 'azure' | 'gcloud' | 'vercel' | 'electron'
   /**
    * Grant configuration
    */
@@ -374,6 +374,10 @@ export type FastifyMiddleware = (server: any, options: any, next: () => void) =>
  * Curveball middleware
  */
 export type CurveballMiddleware = (ctx: any, next?: () => Promise<void>) => Promise<void>
+/**
+ * Electron middleware
+ */
+export type ElectronMiddleware = (details: Electron.OnBeforeRequestListenerDetails, callback: (response: Electron.Response) => void) => Promise<void>
 
 // ----------------------------------------------------------------------------
 
@@ -437,6 +441,11 @@ declare namespace grant {
    */
   function vercel(): (config: GrantConfig | GrantOptions) => GrantHandler & GrantInstance
   function vercel(config: GrantConfig | GrantOptions): GrantHandler & GrantInstance
+  /**
+   * Electron Function handler
+   */
+   function electron(): (config: GrantConfig | GrantOptions) => ElectronMiddleware & GrantInstance
+   function electron(config: GrantConfig | GrantOptions): ElectronMiddleware & GrantInstance
 }
 
 export default grant

--- a/grant.js
+++ b/grant.js
@@ -64,6 +64,9 @@ function grant ({handler, ...rest}) {
   else if (handler === 'vercel') {
     return require('./lib/handler/vercel')(rest)
   }
+  else if (handler === 'electron') {
+    return require('./lib/handler/electron')(rest)
+  }
 }
 
 grant.express = (options) => {
@@ -132,6 +135,11 @@ grant.gcloud = (options) => {
 
 grant.vercel = (options) => {
   var handler = require('./lib/handler/vercel')
+  return options ? handler(options) : handler
+}
+
+grant.electron = (options) => {
+  var handler = require('./lib/handler/electron')
   return options ? handler(options) : handler
 }
 

--- a/lib/handler/electron.js
+++ b/lib/handler/electron.js
@@ -1,0 +1,90 @@
+
+var qs = require('qs')
+var signature = require('cookie-signature')
+var Grant = require('../grant')
+var electron = require('electron')
+
+
+module.exports = function (args = {}) {
+  var grant = Grant(args.config ? args : {config: args})
+  app.config = grant.config
+
+  if (!(args.session && args.session.secret)) {
+    throw new Error('Grant: cookie secret is required')
+  }
+
+  var regex = new RegExp([
+    '^',
+    app.config.defaults.prefix,
+    /(?:\/([^\/\?]+?))/.source, // /:provider
+    /(?:\/([^\/\?]+?))?/.source, // /:override?
+    /(?:\/$|\/?\?+(.*))?$/.source, // querystring
+  ].join(''), 'i')
+
+  var name = name || 'grant'
+  var secret = args.session.secret
+
+  var store = (data) => {
+    return {
+      get: async () => data,
+      set: async (value) => data = value,
+      remove: async () => data = {}
+    }
+  }
+
+  async function app (details, callback) {
+    var cookies = await electron.session.defaultSession.cookies.get({
+      url: details.url,
+      name
+    })
+    var payload = signature.unsign(Object.fromEntries(cookies.map(({name, value}) => [name, value]))[name] || '', secret)
+    var data;
+    try {
+      data = JSON.parse(Buffer.from(payload, 'base64').toString())
+    }
+    catch (err) {
+      data = {grant: {}}
+    }
+    var session = store(data)
+
+    var match = regex.exec(details.url.substring(new URL(details.url).origin.length))
+    if (!match) {
+      callback({})
+      return {session}
+    }
+
+    var {location, session:sess, state} = await grant({
+      method: details.method,
+      params: {provider: match[1], override: match[2]},
+      query: qs.parse(match[3]),
+      body: details.method === 'POST' ? qs.parse(await buffer(details)) : {},
+      state: {},
+      session: (await session.get()).grant
+    })
+
+    await session.set({grant: sess})
+
+    if (location) {
+      var data = Buffer.from(JSON.stringify(await session.get())).toString('base64')
+      await electron.session.defaultSession.cookies.set({
+        url: details.url,
+        name,
+        value: signature.sign(data, secret)
+      })
+      callback({redirectURL: location})
+      return {session, redirect: location, provider: match[1]}
+    }
+    callback({})
+    return {session, response: state.response || sess.response}
+  }
+
+  return app
+}
+
+var buffer = (details) => {
+  var body = '';
+  for (var chunk in details.uploadData) {
+    body += chunk.bytes.toString()
+  }
+  return body
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "aws",
     "azure",
     "google-cloud",
-    "vercel"
+    "vercel",
+    "electron"
   ],
   "license": "MIT",
   "homepage": "https://github.com/simov/grant",
@@ -49,6 +50,7 @@
     "@hapi/yar": "^10.1.1",
     "body-parser": "^1.19.1",
     "cookie-session": "^1.4.0",
+    "electron": "^18.0.0",
     "express": "^4.17.2",
     "express-session": "^1.17.2",
     "fastify": "^3.25.2",


### PR DESCRIPTION
Would you consider adding support for electron.js apps, e.g. for authenticating without having access to redirect_uri?
Tests and documentation is not completed, yet. Electron should possibly not be a default dependency