### PR TITLE
Update Withings Access URL

### DIFF
--- a/config/oauth.json
+++ b/config/oauth.json
@@ -1129,7 +1129,7 @@
   },
   "withings": {
     "authorize_url": "https://account.withings.com/oauth2_user/authorize2",
-    "access_url": "https://account.withings.com/oauth2/token",
+    "access_url": "https://wbsapi.withings.net/v2/oauth2",
     "oauth": 2
   },
   "wordpress": {


### PR DESCRIPTION
The old URL was [deprecated](https://support.withings.com/hc/en-us/articles/360016745358--BREAKING-Deprecating-access-and-refresh-tokens-endpoints) and no longer works as of  02/08/2022