### PR TITLE
Provide `auth` to http module as a string

### DIFF
--- a/lib/flow/oauth2.js
+++ b/lib/flow/oauth2.js
@@ -103,12 +103,12 @@ exports.access = ({request:client}) => async ({provider, input, input:{query, bo
   ) {
     delete options.form.client_id
     delete options.form.client_secret
-    options.auth = {user: provider.key, pass: provider.secret}
+    options.auth = Buffer.from(provider.key + ':' + provider.secret).toString('base64')
   }
   if (/twitter/.test(provider.name)) {
     options.form.client_id = provider.key
     delete options.form.client_secret
-    options.auth = {user: provider.key, pass: provider.secret}
+    options.auth = Buffer.from(provider.key + ':' + provider.secret).toString('base64')
   }
   if (provider.token_endpoint_auth_method === 'private_key_jwt') {
     var jwt = ({kid, x5t, secret}) => ({


### PR DESCRIPTION
Hey,

The [`http` module documentation](https://nodejs.org/api/http.html#httprequesturl-options-callback) lists it as taking a `string`, not object.

> auth [<string>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type) Basic authentication ('user:password') to compute an Authorization header.

It looks like the object form works, but is not officially supported so this updates the logic to use the string version.

The object version is a problem for us as we're using Sentry and it instruments the http module - it's not expecting the object form, so crashes.