### PR TITLE
chore: swap qs for fast-querystring

### DIFF
--- a/examples/transport-querystring/hapi.js
+++ b/examples/transport-querystring/hapi.js
@@ -1,7 +1,7 @@
 
 var Hapi = require('@hapi/hapi')
 var yar = require('@hapi/yar')
-var qs = require('qs')
+var qs = require('fast-querystring')
 var grant = require('../../').hapi()
 
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,7 +1,7 @@
 
 var compose = require('request-compose')
 var oauth = require('request-oauth')
-var qs = require('qs')
+var qs = require('fast-querystring')
 var pkg = require('../package')
 
 

--- a/lib/flow/oauth1.js
+++ b/lib/flow/oauth1.js
@@ -1,5 +1,5 @@
 
-var qs = require('qs')
+var qs = require('fast-querystring')
 var request = require('../client')
 
 

--- a/lib/flow/oauth2.js
+++ b/lib/flow/oauth2.js
@@ -1,6 +1,6 @@
 
 var crypto = require('crypto')
-var qs = require('qs')
+var qs = require('fast-querystring')
 var request = require('../client')
 
 

--- a/lib/handler/aws.js
+++ b/lib/handler/aws.js
@@ -1,5 +1,5 @@
 
-var qs = require('qs')
+var qs = require('fast-querystring')
 var Grant = require('../grant')
 var Session = require('../session')
 

--- a/lib/handler/azure.js
+++ b/lib/handler/azure.js
@@ -1,5 +1,5 @@
 
-var qs = require('qs')
+var qs = require('fast-querystring')
 var Grant = require('../grant')
 var Session = require('../session')
 

--- a/lib/handler/curveball.js
+++ b/lib/handler/curveball.js
@@ -1,5 +1,5 @@
 
-var qs = require('qs')
+var qs = require('fast-querystring')
 var Grant = require('../grant')
 
 

--- a/lib/handler/fastify.js
+++ b/lib/handler/fastify.js
@@ -1,5 +1,5 @@
 
-var qs = require('qs')
+var qs = require('fast-querystring')
 var Grant = require('../grant')
 
 

--- a/lib/handler/gcloud.js
+++ b/lib/handler/gcloud.js
@@ -1,5 +1,5 @@
 
-var qs = require('qs')
+var qs = require('fast-querystring')
 var Grant = require('../grant')
 var Session = require('../session')
 

--- a/lib/handler/hapi-16.js
+++ b/lib/handler/hapi-16.js
@@ -1,6 +1,6 @@
 
 var url = require('url')
-var qs = require('qs')
+var qs = require('fast-querystring')
 var Grant = require('../grant')
 
 

--- a/lib/handler/hapi-17.js
+++ b/lib/handler/hapi-17.js
@@ -1,5 +1,5 @@
 
-var qs = require('qs')
+var qs = require('fast-querystring')
 var Grant = require('../grant')
 
 

--- a/lib/handler/koa-1.js
+++ b/lib/handler/koa-1.js
@@ -1,5 +1,5 @@
 
-var qs = require('qs')
+var qs = require('fast-querystring')
 var Grant = require('../grant')
 
 

--- a/lib/handler/koa-2.js
+++ b/lib/handler/koa-2.js
@@ -1,5 +1,5 @@
 
-var qs = require('qs')
+var qs = require('fast-querystring')
 var Grant = require('../grant')
 
 

--- a/lib/handler/node.js
+++ b/lib/handler/node.js
@@ -1,5 +1,5 @@
 
-var qs = require('qs')
+var qs = require('fast-querystring')
 var Grant = require('../grant')
 var Session = require('../session')
 

--- a/lib/handler/vercel.js
+++ b/lib/handler/vercel.js
@@ -1,5 +1,5 @@
 
-var qs = require('qs')
+var qs = require('fast-querystring')
 var Grant = require('../grant')
 var Session = require('../session')
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,5 +1,5 @@
 
-var qs = require('qs')
+var qs = require('fast-querystring')
 
 
 var tokens = (provider, response) => {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/simov/grant.git"
   },
   "dependencies": {
-    "qs": "^6.14.0",
+    "fast-querystring": "^1.1.2",
     "request-compose": "^2.1.7",
     "request-oauth": "^1.0.1"
   },

--- a/test/client.js
+++ b/test/client.js
@@ -1,7 +1,7 @@
 
 var t = require('assert')
 var http = require('http')
-var qs = require('qs')
+var qs = require('fast-querystring')
 var compose = require('request-compose')
 var request = require('../lib/client')
 

--- a/test/flow/oauth2.js
+++ b/test/flow/oauth2.js
@@ -1,6 +1,6 @@
 
 var t = require('assert')
-var qs = require('qs')
+var qs = require('fast-querystring')
 
 var request = require('request-compose').extend({
   Request: {cookie: require('request-cookie').Request},

--- a/test/handler/handler.js
+++ b/test/handler/handler.js
@@ -1,6 +1,6 @@
 
 var t = require('assert')
-var qs = require('qs')
+var qs = require('fast-querystring')
 
 var request = require('request-compose').extend({
   Request: {cookie: require('request-cookie').Request},

--- a/test/handler/oidc.js
+++ b/test/handler/oidc.js
@@ -9,7 +9,7 @@ var request = require('request-compose').extend({
 var Provider = require('../util/provider'), provider
 var Client = require('../util/client'), client
 
-var qs = require('qs')
+var qs = require('fast-querystring')
 var jws = require('jws')
 var oidc = require('../../lib/oidc')
 var keys = require('../util/keys')

--- a/test/handler/session.js
+++ b/test/handler/session.js
@@ -1,6 +1,6 @@
 
 var t = require('assert')
-var qs = require('qs')
+var qs = require('fast-querystring')
 
 var request = require('request-compose').extend({
   Request: {cookie: require('request-cookie').Request},

--- a/test/util/client.js
+++ b/test/util/client.js
@@ -2,7 +2,7 @@
 var t = require('assert')
 var http = require('http')
 var url = require('url')
-var qs = require('qs')
+var qs = require('fast-querystring')
 var cookie = require('cookie')
 
 var express = () => require('express')()

--- a/test/util/provider.js
+++ b/test/util/provider.js
@@ -1,7 +1,7 @@
 
 var http = require('http')
 var _url = require('url')
-var qs = require('qs')
+var qs = require('fast-querystring')
 
 var buffer = (req, done) => {
   var data = ''


### PR DESCRIPTION
closes https://github.com/simov/grant/issues/320 together with https://github.com/simov/request-oauth/pull/5

`URLSearchParameters` couldn't be used since arrays were being used. See https://github.com/es-tooling/module-replacements/blob/fa9d67b02c9feb28c75bd3509930234b6f5383b1/docs/modules/qs.md for more recommendations

https://npmgraph.js.org/?q=qs - 18 dependencies
https://npmgraph.js.org/?q=fast-querystring - 1 dependency